### PR TITLE
Batch API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *swp
 .cognitoToken
 __pycache__*
+uploads/*

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Blue Core API
 
-API for managing Blue Core resources and workflows using PostgresSQL and Airflow platforms.
+API for managing Blue Core resources and workflows using PostgreSQL and Airflow platforms.
 
 
 ## Project structure
@@ -39,7 +39,7 @@ tests/
     database migrations.
 
 ## Running the application
-To start all of the supporting services (PostgresSQL, etc.):
+To start all of the supporting services (PostgreSQL, etc.):
 `docker-compose up -d`
 
 The Postgres Docker database will be available on port 5432. When the database is first brought up, 
@@ -47,13 +47,14 @@ the `create-db.sql` script is run that creates a `bluecore` database with a
 `bluecore_admin` user. 
 
 After the database is up, change directories to the cloned [Blue Core Data Models][BLUECORE_MODELS] and then from that directory run `uv run alembic upgrade head`
-to create the latest database tables and indicies for the database.
+to create the latest database tables and indices for the database.
 
 
 **In development**: To start the FastAPI rest server in dev mode:
 1. Run `export DATABASE_URL=postgresql://bluecore_admin:bluecore_admin@localhost/bluecore` to add the needed environmental variable 
-2. Run the application at [http://localhost:3000](http://localhost:3000):
+2. Run the application at *http://localhost:3000*
 `uv run fastapi dev src/bluecore/app/main.py --port 3000`
+3. Look at the API docs at *https://localhost:3000/docs/*
 
 This is in development mode and code changes will immediately be loaded without having to restart the server.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,12 +11,16 @@ dependencies = [
   "psycopg2-binary>=2.9.10",
   "rdflib>=7.1.3",
   "bluecore-models>=0.4.1",
+  "python-multipart>=0.0.20",
 ]
 
 [dependency-groups]
 dev = [
   "ruff",
   "pytest-mock-resources[docker]>=2.12.1",
+  "pytest-mock>=3.14.0",
+  "pytest-httpx>=0.35.0",
+  "pytest-asyncio>=0.26.0",
 ]
 
 [build-system]

--- a/src/bluecore/schemas.py
+++ b/src/bluecore/schemas.py
@@ -51,3 +51,12 @@ class WorkUpdateSchema(BaseModel):
 
 class WorkSchema(ResourceBaseSchema):
     type: str = "works"
+
+
+class BatchCreateSchema(BaseModel):
+    uri: Optional[str] = None
+
+
+class BatchSchema(BaseModel):
+    uri: Optional[str] = None
+    workflow_id: str

--- a/src/bluecore/workflow.py
+++ b/src/bluecore/workflow.py
@@ -1,0 +1,35 @@
+import os
+import logging
+
+import httpx
+
+
+async def create_batch_from_uri(uri: str) -> str:
+    """
+    Start an Airflow DAG run to process data at a given URI. Returns the ID for the created DAG Run.
+    A URI can have https, http, s3 or file protocol.
+    """
+    bluecore_workflow_url = os.environ.get(
+        "AIRFLOW_URL", "http://airflow-webserver:8080"
+    )
+    url = f"{bluecore_workflow_url}/api/v1/dags/process/dagRuns"
+
+    auth = httpx.BasicAuth(
+        username=os.environ.get("AIRFLOW_WWW_USER_USERNAME", ""),
+        password=os.environ.get("AIRFLOW_WWW_USER_PASSWORD", ""),
+    )
+
+    async with httpx.AsyncClient(auth=auth) as client:
+        try:
+            resp = await client.post(url, json={"conf": {"file": uri}})
+            resp.raise_for_status()
+            job_id = resp.json().get("dag_run_id")
+        except httpx.HTTPError as e:
+            logging.error(e)
+            raise WorkflowError(f"Bluecore Workflow API at {url} is unavailable.")
+
+    return job_id
+
+
+class WorkflowError(Exception):
+    pass

--- a/tests/api/test_app.py
+++ b/tests/api/test_app.py
@@ -1,6 +1,9 @@
-import pytest
+import re
+from pathlib import Path
 
+import pytest
 from fastapi.testclient import TestClient
+from pytest_httpx import HTTPXMock
 
 from bluecore.app.main import app
 
@@ -14,3 +17,41 @@ def test_index(client):
     response = client.get("/")
     assert response.status_code == 200
     assert response.json() == {"message": "Blue Core API"}
+
+
+@pytest.mark.asyncio
+async def test_create_batch_from_uri(client, httpx_mock: HTTPXMock):
+    # mock the call to airflow api
+    httpx_mock.add_response(
+        method="POST",
+        url=re.compile(r".*/api/v1/dags/process/dagRuns$"),
+        json={"dag_run_id": "12345"},
+    )
+
+    response = client.post("/batches/", json={"uri": "https://example.com"})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["uri"] == "https://example.com"
+    assert data["workflow_id"] == "12345"
+
+
+@pytest.mark.asyncio
+async def test_create_batch_from_upload(client, httpx_mock: HTTPXMock):
+    # mock the call to airflow api
+    httpx_mock.add_response(
+        method="POST",
+        url=re.compile(r".*/api/v1/dags/process/dagRuns$"),
+        json={"dag_run_id": "12345"},
+    )
+
+    response = client.post("/batches/upload/", files={"file": open("README.md", "rb")})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["uri"].endswith("README.md")
+    assert data["workflow_id"] == "12345"
+
+    upload_file = Path("./uploads/") / data["uri"]
+    assert upload_file.is_file()
+    assert upload_file.open("r").read() == open("README.md").read()

--- a/uv.lock
+++ b/uv.lock
@@ -48,12 +48,16 @@ dependencies = [
     { name = "fastapi", extra = ["standard"] },
     { name = "pgvector" },
     { name = "psycopg2-binary" },
+    { name = "python-multipart" },
     { name = "rdflib" },
     { name = "sqlalchemy" },
 ]
 
 [package.dev-dependencies]
 dev = [
+    { name = "pytest-asyncio" },
+    { name = "pytest-httpx" },
+    { name = "pytest-mock" },
     { name = "pytest-mock-resources", extra = ["docker"] },
     { name = "ruff" },
 ]
@@ -64,12 +68,16 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"] },
     { name = "pgvector" },
     { name = "psycopg2-binary", specifier = ">=2.9.10" },
+    { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "rdflib", specifier = ">=7.1.3" },
     { name = "sqlalchemy" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pytest-asyncio", specifier = ">=0.26.0" },
+    { name = "pytest-httpx", specifier = ">=0.35.0" },
+    { name = "pytest-mock", specifier = ">=3.14.0" },
     { name = "pytest-mock-resources", extras = ["docker"], specifier = ">=2.12.1" },
     { name = "ruff" },
 ]
@@ -568,6 +576,43 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083 },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/c4/453c52c659521066969523e87d85d54139bbd17b78f09532fb8eb8cdb58e/pytest_asyncio-0.26.0.tar.gz", hash = "sha256:c4df2a697648241ff39e7f0e4a73050b03f123f760673956cf0d72a4990e312f", size = 54156 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/7f/338843f449ace853647ace35870874f69a764d251872ed1b4de9f234822c/pytest_asyncio-0.26.0-py3-none-any.whl", hash = "sha256:7b51ed894f4fbea1340262bdae5135797ebbe21d8638978e35d31c6d19f72fb0", size = 19694 },
+]
+
+[[package]]
+name = "pytest-httpx"
+version = "0.35.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/89/5b12b7b29e3d0af3a4b9c071ee92fa25a9017453731a38f08ba01c280f4c/pytest_httpx-0.35.0.tar.gz", hash = "sha256:d619ad5d2e67734abfbb224c3d9025d64795d4b8711116b1a13f72a251ae511f", size = 54146 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/ed/026d467c1853dd83102411a78126b4842618e86c895f93528b0528c7a620/pytest_httpx-0.35.0-py3-none-any.whl", hash = "sha256:ee11a00ffcea94a5cbff47af2114d34c5b231c326902458deed73f9c459fd744", size = 19442 },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/90/a955c3ab35ccd41ad4de556596fa86685bf4fc5ffcc62d22d856cfd4e29a/pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0", size = 32814 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/3b/b26f90f74e2986a82df6e7ac7e319b8ea7ccece1caec9f8ab6104dc70603/pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f", size = 9863 },
 ]
 
 [[package]]


### PR DESCRIPTION
Add a `/batches/` API endpoint for creating batches of records to load in bluecore-workflow.

I've tested with mocked out unit tests, but haven't yet run it for real with a running bluecore-workflows since I wasn't sure how to do that in my development environment.

Closes #34
