### PR TITLE
62 ensure work and instance models created at and updated at columns are aligned on create

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 API for managing Blue Core resources and workflows using PostgreSQL and Airflow platforms.
 
 
-## Project structure
+## 🗂️ Project structure
 ```
 bluecore_store_migrations/
 |  |── env.py
@@ -24,21 +24,24 @@ tests/
 └── README.md
 ```
 
+---
 
-## Installation
+## 🛠️ Installation
 
-### Prerequisites
+### 🧰 Prerequisites
 - [uv](https://github.com/astral-sh/uv)
 - [Docker](https://www.docker.com/)
 - [Blue Core Data Models][BLUECORE_MODELS]
  
-### Installation instructions
+### 🔧 Installation instructions
 1.  Run `uv pip install -r requirements.txt`, and follow the instructions that appear.
 2.  Run `docker-compose pull` to pull down all images.
 3.  Clone the [Blue Core Data Models][BLUECORE_MODELS] repository to run the Alembic
     database migrations.
 
-## Running the application
+---
+
+## 🚀 Running the application
 To start all of the supporting services (PostgreSQL, etc.):
 `docker-compose up -d`
 
@@ -49,7 +52,6 @@ the `create-db.sql` script is run that creates a `bluecore` database with a
 After the database is up, change directories to the cloned [Blue Core Data Models][BLUECORE_MODELS] and then from that directory run `uv run alembic upgrade head`
 to create the latest database tables and indices for the database.
 
-
 **In development**: To start the FastAPI rest server in dev mode:
 1. Run `export DATABASE_URL=postgresql://bluecore_admin:bluecore_admin@localhost/bluecore` to add the needed environmental variable 
 2. Run the application at *http://localhost:3000*
@@ -58,17 +60,20 @@ to create the latest database tables and indices for the database.
 
 This is in development mode and code changes will immediately be loaded without having to restart the server.
 
-## Developers
+---
 
-### Linter for Python 
+## 👨‍💻 Developers
+
+### 🧹 Linter for Python 
 Bluecore API uses [ruff](https://docs.astral.sh/ruff/)
 - `uv run ruff check`
 
 To auto-fix errors in both (where possible):
 - `uv run ruff check --fix`
 
-### Unit, feature, and integration tests
-Unit and Feature Tests are written with pytest.
+### 🧪 Unit, feature, and integration tests
+The test suite is written using pytest and is executed via uv.
+All tests are located in the `tests/` directory.
 
 To run all of the tests:
 - `uv run pytest`

--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ Bluecore API uses [ruff](https://docs.astral.sh/ruff/)
 To auto-fix errors in both (where possible):
 - `uv run ruff check --fix`
 
+Check formatting differences without changing files:
+- `uv run ruff format --diff`
+
+Apply Ruff's code formatting:
+- `uv run ruff format`
+
+
+💡 It's a good idea to run both check and format to catch lint and formatting issues. 
+Github Actions will fail if either check or format fails.
+
 ### 🧪 Unit, feature, and integration tests
 The test suite is written using pytest and is executed via uv.
 All tests are located in the `tests/` directory.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-  "ruff",
+  "ruff>=0.11.6",
   "pytest-mock-resources[docker]>=2.12.1",
   "pytest-mock>=3.14.0",
   "pytest-httpx>=0.35.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
   "pgvector",
   "psycopg2-binary>=2.9.10",
   "rdflib>=7.1.3",
-  "bluecore-models>=0.4.1",
+  "bluecore-models>=0.4.3",
   "python-multipart>=0.0.20",
 ]
 

--- a/src/bluecore/app/main.py
+++ b/src/bluecore/app/main.py
@@ -54,7 +54,7 @@ async def create_instance(
         uri=instance.uri,
         work_id=instance.work_id,
         created_at=time_now,
-        updated_at=time_now
+        updated_at=time_now,
     )
     db.add(db_instance)
     db.commit()
@@ -99,7 +99,7 @@ async def create_work(work: WorkCreateSchema, db: Session = Depends(get_db)):
         data=work.data,
         uri=work.uri,
         created_at=time_now,
-        updated_at=time_now
+        updated_at=time_now,
     )
     db.add(db_work)
     db.commit()

--- a/src/bluecore/app/main.py
+++ b/src/bluecore/app/main.py
@@ -1,8 +1,9 @@
 import os
 import sys
+
 from pathlib import Path
 from uuid import uuid4
-
+from datetime import datetime, UTC
 from fastapi import Depends, FastAPI, HTTPException, File, UploadFile
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -47,8 +48,13 @@ async def index():
 async def create_instance(
     instance: InstanceCreateSchema, db: Session = Depends(get_db)
 ):
+    time_now = datetime.now(UTC)
     db_instance = Instance(
-        data=instance.data, uri=instance.uri, work_id=instance.work_id
+        data=instance.data,
+        uri=instance.uri,
+        work_id=instance.work_id,
+        created_at=time_now,
+        updated_at=time_now
     )
     db.add(db_instance)
     db.commit()
@@ -88,7 +94,13 @@ async def update_instance(
 
 @app.post("/works/", response_model=WorkSchema, status_code=201)
 async def create_work(work: WorkCreateSchema, db: Session = Depends(get_db)):
-    db_work = Work(data=work.data, uri=work.uri)
+    time_now = datetime.now(UTC)
+    db_work = Work(
+        data=work.data,
+        uri=work.uri,
+        created_at=time_now,
+        updated_at=time_now
+    )
     db.add(db_work)
     db.commit()
     db.refresh(db_work)

--- a/tests/api/test_instance.py
+++ b/tests/api/test_instance.py
@@ -76,6 +76,11 @@ def test_create_instance(client):
     assert data["data"] == payload["data"]
     assert data["uri"] == payload["uri"]
 
+    # Assert timestamps exist and are identical
+    assert "created_at" in data
+    assert "updated_at" in data
+    assert data["created_at"] == data["updated_at"], "created_at and updated_at should match on creation"
+
 
 def test_update_instance(db_session, client):
     db_session.add(
@@ -94,3 +99,8 @@ def test_update_instance(db_session, client):
     get_response = client.get("/instances/2")
     data = get_response.json()
     assert data["uri"] == new_uri
+
+    # Assert timestamps exist and are now different
+    assert "created_at" in data
+    assert "updated_at" in data
+    assert data["created_at"] != data["updated_at"], "created_at and updated_at should not match on update"

--- a/tests/api/test_instance.py
+++ b/tests/api/test_instance.py
@@ -79,7 +79,9 @@ def test_create_instance(client):
     # Assert timestamps exist and are identical
     assert "created_at" in data
     assert "updated_at" in data
-    assert data["created_at"] == data["updated_at"], "created_at and updated_at should match on creation"
+    assert data["created_at"] == data["updated_at"], (
+        "created_at and updated_at should match on creation"
+    )
 
 
 def test_update_instance(db_session, client):
@@ -103,4 +105,6 @@ def test_update_instance(db_session, client):
     # Assert timestamps exist and are now different
     assert "created_at" in data
     assert "updated_at" in data
-    assert data["created_at"] != data["updated_at"], "created_at and updated_at should not match on update"
+    assert data["created_at"] != data["updated_at"], (
+        "created_at and updated_at should not match on update"
+    )

--- a/tests/api/test_work.py
+++ b/tests/api/test_work.py
@@ -81,6 +81,11 @@ def test_create_work(client):
 
     assert data["data"] == payload["data"]
 
+    # Assert timestamps exist and are identical
+    assert "created_at" in data
+    assert "updated_at" in data
+    assert data["created_at"] == data["updated_at"], "created_at and updated_at should match on creation"
+
 
 def test_update_work(client):
     payload = {
@@ -120,3 +125,8 @@ def test_update_work(client):
     )
 
     assert str(name) == "A New Work Name"
+
+    # Assert timestamps exist and are now different
+    assert "created_at" in data
+    assert "updated_at" in data
+    assert data["created_at"] != data["updated_at"], "created_at and updated_at should not match on update"

--- a/tests/api/test_work.py
+++ b/tests/api/test_work.py
@@ -84,7 +84,9 @@ def test_create_work(client):
     # Assert timestamps exist and are identical
     assert "created_at" in data
     assert "updated_at" in data
-    assert data["created_at"] == data["updated_at"], "created_at and updated_at should match on creation"
+    assert data["created_at"] == data["updated_at"], (
+        "created_at and updated_at should match on creation"
+    )
 
 
 def test_update_work(client):
@@ -129,4 +131,6 @@ def test_update_work(client):
     # Assert timestamps exist and are now different
     assert "created_at" in data
     assert "updated_at" in data
-    assert data["created_at"] != data["updated_at"], "created_at and updated_at should not match on update"
+    assert data["created_at"] != data["updated_at"], (
+        "created_at and updated_at should not match on update"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -64,7 +64,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bluecore-models", specifier = ">=0.4.1" },
+    { name = "bluecore-models", specifier = ">=0.4.3" },
     { name = "fastapi", extras = ["standard"] },
     { name = "pgvector" },
     { name = "psycopg2-binary", specifier = ">=2.9.10" },
@@ -84,16 +84,16 @@ dev = [
 
 [[package]]
 name = "bluecore-models"
-version = "0.4.1"
+version = "0.4.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "alembic" },
     { name = "psycopg2-binary" },
     { name = "rdflib" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b5/c3/86ef97c3c579ff50171bf6d425f6ad377ac965e8b37d070d0209b9d625d0/bluecore_models-0.4.1.tar.gz", hash = "sha256:62dd345a0ef31e6562b96d2e26f0e962ba66ec3cfbad57cda2f7312458d3fed4", size = 31917 }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/c5/9823d7ac9b4e174ddd7eb439dcf0198d9de08aa9988962170ce6337470b5/bluecore_models-0.4.3.tar.gz", hash = "sha256:131ffd4d7468e3c3b9e2c45f6209be546760c938db3d9851fc47d8d3900eba11", size = 32940 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/53/796a89f2691166401e96c5281bd5aa645abdb5ad4e17c403e482aabe6a14/bluecore_models-0.4.1-py3-none-any.whl", hash = "sha256:f2eb95836295d09aaab5f621c516c776eb0f8ed524a1e2c27e91bc71abc6152d", size = 9432 },
+    { url = "https://files.pythonhosted.org/packages/d0/f2/80f7e33a3b8a963e8af0077ba5999da608415716af283b81306293a2578a/bluecore_models-0.4.3-py3-none-any.whl", hash = "sha256:21d47ab9554ed0a7a5efd99cae7f07b3b901d5bf5929c7bd4a282114f604b79a", size = 9941 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -79,7 +79,7 @@ dev = [
     { name = "pytest-httpx", specifier = ">=0.35.0" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
     { name = "pytest-mock-resources", extras = ["docker"], specifier = ">=2.12.1" },
-    { name = "ruff" },
+    { name = "ruff", specifier = ">=0.11.6" },
 ]
 
 [[package]]
@@ -733,27 +733,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.9.5"
+version = "0.11.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/02/74/6c359f6b9ed85b88df6ef31febce18faeb852f6c9855651dfb1184a46845/ruff-0.9.5.tar.gz", hash = "sha256:11aecd7a633932875ab3cb05a484c99970b9d52606ce9ea912b690b02653d56c", size = 3634177 }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/11/bcef6784c7e5d200b8a1f5c2ddf53e5da0efec37e6e5a44d163fb97e04ba/ruff-0.11.6.tar.gz", hash = "sha256:bec8bcc3ac228a45ccc811e45f7eb61b950dbf4cf31a67fa89352574b01c7d79", size = 4010053 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/4b/82b7c9ac874e72b82b19fd7eab57d122e2df44d2478d90825854f9232d02/ruff-0.9.5-py3-none-linux_armv6l.whl", hash = "sha256:d466d2abc05f39018d53f681fa1c0ffe9570e6d73cde1b65d23bb557c846f442", size = 11681264 },
-    { url = "https://files.pythonhosted.org/packages/27/5c/f5ae0a9564e04108c132e1139d60491c0abc621397fe79a50b3dc0bd704b/ruff-0.9.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:38840dbcef63948657fa7605ca363194d2fe8c26ce8f9ae12eee7f098c85ac8a", size = 11657554 },
-    { url = "https://files.pythonhosted.org/packages/2a/83/c6926fa3ccb97cdb3c438bb56a490b395770c750bf59f9bc1fe57ae88264/ruff-0.9.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d56ba06da53536b575fbd2b56517f6f95774ff7be0f62c80b9e67430391eeb36", size = 11088959 },
-    { url = "https://files.pythonhosted.org/packages/af/a7/42d1832b752fe969ffdbfcb1b4cb477cb271bed5835110fb0a16ef31ab81/ruff-0.9.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f7cb2a01da08244c50b20ccfaeb5972e4228c3c3a1989d3ece2bc4b1f996001", size = 11902041 },
-    { url = "https://files.pythonhosted.org/packages/53/cf/1fffa09fb518d646f560ccfba59f91b23c731e461d6a4dedd21a393a1ff1/ruff-0.9.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:96d5c76358419bc63a671caac70c18732d4fd0341646ecd01641ddda5c39ca0b", size = 11421069 },
-    { url = "https://files.pythonhosted.org/packages/09/27/bb8f1b7304e2a9431f631ae7eadc35550fe0cf620a2a6a0fc4aa3d736f94/ruff-0.9.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:deb8304636ed394211f3a6d46c0e7d9535b016f53adaa8340139859b2359a070", size = 12625095 },
-    { url = "https://files.pythonhosted.org/packages/d7/ce/ab00bc9d3df35a5f1b64f5117458160a009f93ae5caf65894ebb63a1842d/ruff-0.9.5-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:df455000bf59e62b3e8c7ba5ed88a4a2bc64896f900f311dc23ff2dc38156440", size = 13257797 },
-    { url = "https://files.pythonhosted.org/packages/88/81/c639a082ae6d8392bc52256058ec60f493c6a4d06d5505bccface3767e61/ruff-0.9.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de92170dfa50c32a2b8206a647949590e752aca8100a0f6b8cefa02ae29dce80", size = 12763793 },
-    { url = "https://files.pythonhosted.org/packages/b3/d0/0a3d8f56d1e49af466dc770eeec5c125977ba9479af92e484b5b0251ce9c/ruff-0.9.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3d28532d73b1f3f627ba88e1456f50748b37f3a345d2be76e4c653bec6c3e393", size = 14386234 },
-    { url = "https://files.pythonhosted.org/packages/04/70/e59c192a3ad476355e7f45fb3a87326f5219cc7c472e6b040c6c6595c8f0/ruff-0.9.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2c746d7d1df64f31d90503ece5cc34d7007c06751a7a3bbeee10e5f2463d52d2", size = 12437505 },
-    { url = "https://files.pythonhosted.org/packages/55/4e/3abba60a259d79c391713e7a6ccabf7e2c96e5e0a19100bc4204f1a43a51/ruff-0.9.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:11417521d6f2d121fda376f0d2169fb529976c544d653d1d6044f4c5562516ee", size = 11884799 },
-    { url = "https://files.pythonhosted.org/packages/a3/db/b0183a01a9f25b4efcae919c18fb41d32f985676c917008620ad692b9d5f/ruff-0.9.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:5b9d71c3879eb32de700f2f6fac3d46566f644a91d3130119a6378f9312a38e1", size = 11527411 },
-    { url = "https://files.pythonhosted.org/packages/0a/e4/3ebfcebca3dff1559a74c6becff76e0b64689cea02b7aab15b8b32ea245d/ruff-0.9.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:2e36c61145e70febcb78483903c43444c6b9d40f6d2f800b5552fec6e4a7bb9a", size = 12078868 },
-    { url = "https://files.pythonhosted.org/packages/ec/b2/5ab808833e06c0a1b0d046a51c06ec5687b73c78b116e8d77687dc0cd515/ruff-0.9.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:2f71d09aeba026c922aa7aa19a08d7bd27c867aedb2f74285a2639644c1c12f5", size = 12524374 },
-    { url = "https://files.pythonhosted.org/packages/e0/51/1432afcc3b7aa6586c480142caae5323d59750925c3559688f2a9867343f/ruff-0.9.5-py3-none-win32.whl", hash = "sha256:134f958d52aa6fdec3b294b8ebe2320a950d10c041473c4316d2e7d7c2544723", size = 9853682 },
-    { url = "https://files.pythonhosted.org/packages/b7/ad/c7a900591bd152bb47fc4882a27654ea55c7973e6d5d6396298ad3fd6638/ruff-0.9.5-py3-none-win_amd64.whl", hash = "sha256:78cc6067f6d80b6745b67498fb84e87d32c6fc34992b52bffefbdae3442967d6", size = 10865744 },
-    { url = "https://files.pythonhosted.org/packages/75/d9/fde7610abd53c0c76b6af72fc679cb377b27c617ba704e25da834e0a0608/ruff-0.9.5-py3-none-win_arm64.whl", hash = "sha256:18a29f1a005bddb229e580795627d297dfa99f16b30c7039e73278cf6b5f9fa9", size = 10064595 },
+    { url = "https://files.pythonhosted.org/packages/6e/1f/8848b625100ebcc8740c8bac5b5dd8ba97dd4ee210970e98832092c1635b/ruff-0.11.6-py3-none-linux_armv6l.whl", hash = "sha256:d84dcbe74cf9356d1bdb4a78cf74fd47c740bf7bdeb7529068f69b08272239a1", size = 10248105 },
+    { url = "https://files.pythonhosted.org/packages/e0/47/c44036e70c6cc11e6ee24399c2a1e1f1e99be5152bd7dff0190e4b325b76/ruff-0.11.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9bc583628e1096148011a5d51ff3c836f51899e61112e03e5f2b1573a9b726de", size = 11001494 },
+    { url = "https://files.pythonhosted.org/packages/ed/5b/170444061650202d84d316e8f112de02d092bff71fafe060d3542f5bc5df/ruff-0.11.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f2959049faeb5ba5e3b378709e9d1bf0cab06528b306b9dd6ebd2a312127964a", size = 10352151 },
+    { url = "https://files.pythonhosted.org/packages/ff/91/f02839fb3787c678e112c8865f2c3e87cfe1744dcc96ff9fc56cfb97dda2/ruff-0.11.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:63c5d4e30d9d0de7fedbfb3e9e20d134b73a30c1e74b596f40f0629d5c28a193", size = 10541951 },
+    { url = "https://files.pythonhosted.org/packages/9e/f3/c09933306096ff7a08abede3cc2534d6fcf5529ccd26504c16bf363989b5/ruff-0.11.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:26a4b9a4e1439f7d0a091c6763a100cef8fbdc10d68593df6f3cfa5abdd9246e", size = 10079195 },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/a87f8933fccbc0d8c653cfbf44bedda69c9582ba09210a309c066794e2ee/ruff-0.11.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b5edf270223dd622218256569636dc3e708c2cb989242262fe378609eccf1308", size = 11698918 },
+    { url = "https://files.pythonhosted.org/packages/52/7d/8eac0bd083ea8a0b55b7e4628428203441ca68cd55e0b67c135a4bc6e309/ruff-0.11.6-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:f55844e818206a9dd31ff27f91385afb538067e2dc0beb05f82c293ab84f7d55", size = 12319426 },
+    { url = "https://files.pythonhosted.org/packages/c2/dc/d0c17d875662d0c86fadcf4ca014ab2001f867621b793d5d7eef01b9dcce/ruff-0.11.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1d8f782286c5ff562e4e00344f954b9320026d8e3fae2ba9e6948443fafd9ffc", size = 11791012 },
+    { url = "https://files.pythonhosted.org/packages/f9/f3/81a1aea17f1065449a72509fc7ccc3659cf93148b136ff2a8291c4bc3ef1/ruff-0.11.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:01c63ba219514271cee955cd0adc26a4083df1956d57847978383b0e50ffd7d2", size = 13949947 },
+    { url = "https://files.pythonhosted.org/packages/61/9f/a3e34de425a668284e7024ee6fd41f452f6fa9d817f1f3495b46e5e3a407/ruff-0.11.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15adac20ef2ca296dd3d8e2bedc6202ea6de81c091a74661c3666e5c4c223ff6", size = 11471753 },
+    { url = "https://files.pythonhosted.org/packages/df/c5/4a57a86d12542c0f6e2744f262257b2aa5a3783098ec14e40f3e4b3a354a/ruff-0.11.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4dd6b09e98144ad7aec026f5588e493c65057d1b387dd937d7787baa531d9bc2", size = 10417121 },
+    { url = "https://files.pythonhosted.org/packages/58/3f/a3b4346dff07ef5b862e2ba06d98fcbf71f66f04cf01d375e871382b5e4b/ruff-0.11.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:45b2e1d6c0eed89c248d024ea95074d0e09988d8e7b1dad8d3ab9a67017a5b03", size = 10073829 },
+    { url = "https://files.pythonhosted.org/packages/93/cc/7ed02e0b86a649216b845b3ac66ed55d8aa86f5898c5f1691797f408fcb9/ruff-0.11.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:bd40de4115b2ec4850302f1a1d8067f42e70b4990b68838ccb9ccd9f110c5e8b", size = 11076108 },
+    { url = "https://files.pythonhosted.org/packages/39/5e/5b09840fef0eff1a6fa1dea6296c07d09c17cb6fb94ed5593aa591b50460/ruff-0.11.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:77cda2dfbac1ab73aef5e514c4cbfc4ec1fbef4b84a44c736cc26f61b3814cd9", size = 11512366 },
+    { url = "https://files.pythonhosted.org/packages/6f/4c/1cd5a84a412d3626335ae69f5f9de2bb554eea0faf46deb1f0cb48534042/ruff-0.11.6-py3-none-win32.whl", hash = "sha256:5151a871554be3036cd6e51d0ec6eef56334d74dfe1702de717a995ee3d5b287", size = 10485900 },
+    { url = "https://files.pythonhosted.org/packages/42/46/8997872bc44d43df986491c18d4418f1caff03bc47b7f381261d62c23442/ruff-0.11.6-py3-none-win_amd64.whl", hash = "sha256:cce85721d09c51f3b782c331b0abd07e9d7d5f775840379c640606d3159cae0e", size = 11558592 },
+    { url = "https://files.pythonhosted.org/packages/d7/6a/65fecd51a9ca19e1477c3879a7fda24f8904174d1275b419422ac00f6eee/ruff-0.11.6-py3-none-win_arm64.whl", hash = "sha256:3567ba0d07fb170b1b48d944715e3294b77f5b7679e8ba258199a250383ccb79", size = 10682766 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why was this change made?
This change was made to ensure aligned timestamps in `Work` and `Instance` models:
- Ensuring `created_at` and `updated_at` timestamps are properly set and validated for both `Instance` and `Work` models on creation and update.
- Adding validation tests to ensure this timestamp behavior.
- Aligning local and CI environments on `ruff` version (v0.11.6) for consistent linting and formatting behavior.

## How was this change tested?
- Unit and feature tests using `pytest` 
  - Instance and Work creation includes equal `created_at` and `updated_at` values.
  - Updates correctly change the `updated_at` value only.
- Verified that `uv run pytest` passed all existing and new tests.
- Manually ran `uv run ruff check` and `uv run ruff format --diff` to ensure linting and formatting passed locally.
- Confirmed GitHub Actions CI formatting checks triggered expected diffs and passed after formatting.

## Which documentation and/or configurations were updated?

- `README.md`: 
  - Included new linting and formatting instructions using Ruff.
- `pyproject.toml`: 
  - Updated `bluecore-models` to version `0.4.3`.
  - Pinned Ruff version to `>=0.11.6` to match GitHub Action behavior and eliminate format discrepancies.


