### PR TITLE
67 update to allow api to work in development when keycloak container not used

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ the `create-db.sql` script is run that creates a `bluecore` database with a
 After the database is up, change directories to the cloned [Blue Core Data Models][BLUECORE_MODELS] and then from that directory run `uv run alembic upgrade head`
 to create the latest database tables and indices for the database.
 
-
 **In development**: To start the FastAPI rest server in dev mode:
 1. Run `export DATABASE_URL=postgresql://bluecore_admin:bluecore_admin@localhost/bluecore` to add the needed environmental variable 
 2. Run the application at *http://localhost:3000*

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ This is in development mode and code changes will immediately be loaded without 
 
 ## Developers
 
+### 🔐 Bypassing Keycloak 
+To access the API without needing to authenticate with Keycloak: 
+* run `export DEVELOPER_MODE=true` before running the application. 
+
 ### Linter for Python 
 Bluecore API uses [ruff](https://docs.astral.sh/ruff/)
 - `uv run ruff check`

--- a/src/bluecore/app/main.py
+++ b/src/bluecore/app/main.py
@@ -17,9 +17,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/../../")
-
 from bluecore_models.models import Instance, Work
-
 from bluecore import workflow
 from bluecore.schemas import (
     BatchCreateSchema,
@@ -32,8 +30,6 @@ from bluecore.schemas import (
     WorkUpdateSchema,
 )
 
-from bluecore_models.models import Instance, Work
-
 keycloak_config = KeycloakConfiguration(
     url=os.getenv("KEYCLOAK_URL"),
     realm=os.getenv("KEYCLOAK_REALM"),
@@ -45,19 +41,25 @@ keycloak_config = KeycloakConfiguration(
 
 app = FastAPI()
 
+
 # ==============================================================================
 # Bypass Keycloak auth in local-only dev mode by setting DEVELOPER_MODE=true
 # Sets up mocked auth and user dependencies instead of requiring real tokens
 # ------------------------------------------------------------------------------
 def enable_developer_mode(app):
-    developer_permissions = ["create", "update"] # update to add more permissions
+    developer_permissions = ["create", "update"]  # update to add more permissions
+
     async def mocked_get_auth(request: Request):
         return developer_permissions
+
     async def mocked_get_user(request: Request):
         return "developer"
+
     app.dependency_overrides[get_auth] = mocked_get_auth
     app.dependency_overrides[get_user] = mocked_get_user
-    print("\033[1;35m🚧 DEVELOPER_MODE is ON — Keycloak is bypassed with mock permissions\033[0m")
+    print(
+        "\033[1;35m🚧 DEVELOPER_MODE is ON — Keycloak is bypassed with mock permissions\033[0m"
+    )
 
 
 async def scope_mapper(claim_auth: list) -> list:


### PR DESCRIPTION
## Why was this change made?
To improve local development workflow by allowing developers to bypass
Keycloak authentication when `DEVELOPER_MODE=true` is set in the environment.
This enables faster iteration and testing of API endpoints without requiring
valid Keycloak tokens or running a full auth infrastructure stack.

This change also consolidates auth overrides into a reusable
`enable_developer_mode(app)` function and adds ANSI-colored console output
to clearly indicate when developer mode is active.

## How was this change tested?
- Manually set `DEVELOPER_MODE=true` in the shell environment
- Started the server locally using `uv run fastapi dev src/bluecore/app/main.py --port 3000`
- Verified that protected endpoints worked without an Authorization header
- Confirmed correct roles were returned via the mocked auth logic
- Reviewed that the terminal output prints a magenta-colored dev mode warning

## Which documentation and/or configurations were updated?
- Added a new section to `README.md` under "👨‍💻 Developers" explaining how to
  bypass Keycloak using `DEVELOPER_MODE=true`
- Updated `main.py` with an inline dev-mode toggle and helper function



