### PR TITLE
Move get_db to database.py so other routes can share it

### DIFF
--- a/src/bluecore/app/main.py
+++ b/src/bluecore/app/main.py
@@ -13,12 +13,12 @@ from fastapi_keycloak_middleware import (
     get_auth,
     setup_keycloak_middleware,
 )
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/../../")
 from bluecore_models.models import Instance, Work
 from bluecore import workflow
+from bluecore.database import get_db
 from bluecore.schemas.schemas import (
     BatchCreateSchema,
     BatchSchema,
@@ -77,19 +77,6 @@ else:
         exclude_patterns=["/docs", "/openapi.json"],
         scope_mapper=scope_mapper,
     )
-
-
-DATABASE_URL = os.getenv("DATABASE_URL")
-engine = create_engine(DATABASE_URL)
-Session = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-
-
-def get_db():
-    db = Session()
-    try:
-        yield db
-    finally:
-        db.close()
 
 
 @app.get("/")

--- a/src/bluecore/database.py
+++ b/src/bluecore/database.py
@@ -1,0 +1,15 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+import os
+
+db_url = os.getenv("DATABASE_URL", "")
+engine = create_engine(db_url)
+Session = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def get_db():
+    db = Session()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,7 +86,7 @@ def client(mocker, db_session, app):
         ],
     )
 
-    from bluecore.app.main import get_db
+    from bluecore.database import get_db
 
     def override_get_db():
         db = db_session


### PR DESCRIPTION
## Why was this change made?
Other APIRouter would be able to share same DB dependency this way.


## How was this change tested?
All tests passed.


## Which documentation and/or configurations were updated?




