### PR TITLE
Build Docker image on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+name: Build and Release Docker Image
+
+on:
+  release:
+    types:
+      published
+
+jobs:
+  build_and_publish:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build and push Docker image
+        run: |
+          docker login --username blue-core-lod --password ${{ secrets.GITHUB_TOKEN }} ghcr.io
+          docker build . --tag ghcr.io/blue-core-lod/bluecore_api:latest
+          docker push ghcr.io/blue-core-lod/bluecore_api:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,22 @@
-FROM cimg/node:16.8
+FROM python:3.12-slim-bookworm
 
-WORKDIR /home/circleci
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates git
 
-COPY --chown=circleci:circleci package.json .
-COPY --chown=circleci:circleci package-lock.json .
+ADD https://astral.sh/uv/install.sh /uv-installer.sh
 
-RUN npm install
+RUN sh /uv-installer.sh && rm /uv-installer.sh
 
-COPY --chown=circleci:circleci . .
+ENV PATH="/root/.local/bin/:$PATH"
 
-ENV NODE_ENV production
+WORKDIR /bluecore_api
 
-CMD ["npm", "start"]
+COPY src src
+ADD pyproject.toml .
+ADD uv.lock .
+ADD README.md .
+
+RUN uv sync
+RUN uv build
+RUN uv pip install --system dist/*.whl
+
+CMD ["uv", "run", "fastapi", "run", "src/bluecore/app/main.py", "--port", "8100", "--root-path", "/api"] 


### PR DESCRIPTION
This adds a Github Action similar to bluecore-workflows which will build a Docker image when a release is published on Github.

The Dockerfile was adapted from the existing one that is being used in Bluecore Terraform:

https://github.com/blue-core-lod/terraform/blob/main/api/Dockerfile

The thought is that our Terraform Docker Compose should be able to reference these images rather than needing to build them...

Closes #71