### PR TITLE
79: Added paths to exclude pattern

### DIFF
--- a/src/bluecore/app/main.py
+++ b/src/bluecore/app/main.py
@@ -74,7 +74,7 @@ else:
     setup_keycloak_middleware(
         app,
         keycloak_configuration=keycloak_config,
-        exclude_patterns=["/docs", "/openapi.json"],
+        exclude_patterns=["/docs", "/openapi.json", "/api/docs", "/api/openapi.json"],
         scope_mapper=scope_mapper,
     )
 


### PR DESCRIPTION
## Why was this change made?
so exclude logic works with /api path when using terraform


## How was this change tested?
Locally to ensure docs page was accessible after change


## Which documentation and/or configurations were updated?
* `main.py`
  * `exclude_patterns` values changed to include `/api/docs` and `/api/openapi.json`



