### PR TITLE
Fixes default for Airflow URL

### DIFF
--- a/src/bluecore/workflow.py
+++ b/src/bluecore/workflow.py
@@ -10,7 +10,7 @@ async def create_batch_from_uri(uri: str) -> str:
     A URI can have https, http, s3 or file protocol.
     """
     bluecore_workflow_url = os.environ.get(
-        "AIRFLOW_URL", "http://airflow-webserver:8080"
+        "AIRFLOW_URL", "http://airflow-webserver:8080/workflows"
     )
     url = f"{bluecore_workflow_url}/api/v1/dags/process/dagRuns"
 


### PR DESCRIPTION
## Why was this change made?
When Airflow is running in Docker with nginx reverse proxy with `/workflows` prefix the default is returning an error:
`Bluecore Workflow API at http://airflow-webserver:8080/api/v1/dags/process/dagRuns is unavailable.`


## How was this change tested?
Passes unit tests, logging into the running `bc_api` container resolves `http://airflow-webserver:8080/workflows/api/v1/dags/process/dagRuns` correctly


## Which documentation and/or configurations were updated?
n/a



