### PR TITLE
Uses the correct DAG for workflow API call

### DIFF
--- a/src/bluecore/workflow.py
+++ b/src/bluecore/workflow.py
@@ -12,7 +12,7 @@ async def create_batch_from_uri(uri: str) -> str:
     bluecore_workflow_url = os.environ.get(
         "AIRFLOW_URL", "http://airflow-webserver:8080/workflows"
     )
-    url = f"{bluecore_workflow_url}/api/v1/dags/process/dagRuns"
+    url = f"{bluecore_workflow_url}/api/v1/dags/resource_loader/dagRuns"
 
     auth = httpx.BasicAuth(
         username=os.environ.get("AIRFLOW_WWW_USER_USERNAME", ""),

--- a/tests/api/test_app.py
+++ b/tests/api/test_app.py
@@ -17,7 +17,7 @@ async def test_create_batch_from_uri(client, httpx_mock: HTTPXMock):
     # mock the call to airflow api
     httpx_mock.add_response(
         method="POST",
-        url=re.compile(r".*/api/v1/dags/process/dagRuns$"),
+        url=re.compile(r".*/api/v1/dags/resource_loader/dagRuns$"),
         json={"dag_run_id": "12345"},
     )
 
@@ -38,7 +38,7 @@ async def test_create_batch_from_upload(client, httpx_mock: HTTPXMock):
     # mock the call to airflow api
     httpx_mock.add_response(
         method="POST",
-        url=re.compile(r".*/api/v1/dags/process/dagRuns$"),
+        url=re.compile(r".*/api/v1/dags/resource_loader/dagRuns$"),
         json={"dag_run_id": "12345"},
     )
 


### PR DESCRIPTION
## Why was this change made?
The existing call to the workflow API was using the wrong DAG.

## How was this change tested?
Unit tests, accessed the API from the running container


## Which documentation and/or configurations were updated?
n/a



