### PR TITLE
89: updated keycloak env names

### DIFF
--- a/src/bluecore/app/main.py
+++ b/src/bluecore/app/main.py
@@ -66,8 +66,8 @@ else:
     keycloak_config = KeycloakConfiguration(
         url=os.getenv("KEYCLOAK_URL"),
         realm=os.getenv("KEYCLOAK_REALM"),
-        client_id=os.getenv("KEYCLOAK_CLIENT_ID"),
-        client_secret=os.getenv("KEYCLOAK_CLIENT_SECRET"),
+        client_id=os.getenv("API_KEYCLOAK_CLIENT_ID"),
+        client_secret=os.getenv("API_KEYCLOAK_CLIENT_SECRET"),
         authorization_method=AuthorizationMethod.CLAIM,
         authorization_claim="realm_access",
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,8 +27,8 @@ if os.getenv("DATABASE_URL") is None:
 
 os.environ["KEYCLOAK_URL"] = "http://localhost:8080/auth"
 os.environ["KEYCLOAK_REALM"] = "bluecore"
-os.environ["KEYCLOAK_CLIENT_ID"] = "bluecore"
-os.environ["KEYCLOAK_CLIENT_SECRET"] = "abcded235"
+os.environ["API_KEYCLOAK_CLIENT_ID"] = "bluecore"
+os.environ["API_KEYCLOAK_CLIENT_SECRET"] = "abcded235"
 
 os.environ["ACTIVITY_STREAMS_PAGE_LENGTH"] = "2"
 os.environ["ACTIVITY_STREAMS_HOST"] = "http://127.0.0.1:3000"


### PR DESCRIPTION
## Why was this change made?
To facilitate using multiple clients and secrets with an easy to understand naming pattern


## How was this change tested?
It was tested in development in terraform locally with mutliple keycloak clients


## Which documentation and/or configurations were updated?
- keycloak_config was updated to accept the new env names



