### PR TITLE
Use Airflow pattern for uploaded files

### DIFF
--- a/tests/api/test_app.py
+++ b/tests/api/test_app.py
@@ -53,6 +53,6 @@ async def test_create_batch_from_upload(client, httpx_mock: HTTPXMock):
     assert data["uri"].endswith("README.md")
     assert data["workflow_id"] == "12345"
 
-    upload_file = Path("./uploads/") / data["uri"]
+    upload_file = Path("./uploads/") / data["uri"].split("uploads/")[-1]
     assert upload_file.is_file()
     assert upload_file.open("r").read() == open("README.md").read()


### PR DESCRIPTION
## Why was this change made?
Uses Airflow `resource_loader` DAG pattern for file uploads as httpx doesn't support the `file://` prefix.

**NOTE:** Terraform PR https://github.com/blue-core-lod/terraform/pull/38 needs to merged for the API and Workflows to share a common uploads directory.

## How was this change tested?
Unit tests


## Which documentation and/or configurations were updated?
n/a



