### PR TITLE
93 build dev compose file for api

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,0 +1,23 @@
+# Dockerfile.dev
+
+FROM python:3.12-slim-bookworm
+
+# Install required system packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  curl ca-certificates git && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+
+# Install uv (Python dependency manager)
+ADD https://astral.sh/uv/install.sh /uv-installer.sh
+RUN sh /uv-installer.sh && rm /uv-installer.sh
+
+ENV PATH="/root/.local/bin/:$PATH"
+
+WORKDIR /app
+
+COPY . .
+
+RUN uv pip install --system -r requirements.txt
+
+CMD ["uv", "run", "fastapi", "run", "src/bluecore/app/main.py", "--port", "8100", "--root-path", "/api"]

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -16,6 +16,7 @@ WORKDIR /app
 
 COPY . .
 
+RUN uv pip compile pyproject.toml -o requirements.txt
 RUN uv pip install --system -r requirements.txt
 
-CMD ["uv", "run", "fastapi", "run", "src/bluecore/app/main.py", "--port", "8100", "--root-path", "/api"]
+CMD ["uv", "run", "fastapi", "dev", "src/bluecore/app/main.py", "--host", "0.0.0.0", "--port", "8100", "--root-path", "/api"]

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,5 +1,3 @@
-# Dockerfile.dev
-
 FROM python:3.12-slim-bookworm
 
 # Install required system packages

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ to create the latest database tables and indices for the database.
 
 **🛠️ In development (Non Dockerized)**: To start the FastAPI rest server in dev mode:
 > ⚠️ Note: This method only runs the api server and not the supporting services in docker (keycloak, nginx, etc.)
-> [Recommended: Run with Docker](#running-locally-with-docker)
+> [Recommended: Run with Docker](#-running-locally-with-docker)
 
 1. Run `export DATABASE_URL=postgresql://bluecore_admin:bluecore_admin@localhost/bluecore` to add the needed environmental variable 
 2. Run the application at *http://localhost:3000*

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ to create the latest database tables and indices for the database.
 
 **🛠️ In development (Non Dockerized)**: To start the FastAPI rest server in dev mode:
 > ⚠️ Note: This method only runs the api server and not the supporting services in docker (keycloak, nginx, etc.)
-> [Recommended: Run with Docker](#Running Locally with Docker)
+> [Recommended: Run with Docker](#running-locally-with-docker)
 
 1. Run `export DATABASE_URL=postgresql://bluecore_admin:bluecore_admin@localhost/bluecore` to add the needed environmental variable 
 2. Run the application at *http://localhost:3000*

--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ the `create-db.sql` script is run that creates a `bluecore` database with a
 After the database is up, change directories to the cloned [Blue Core Data Models][BLUECORE_MODELS] and then from that directory run `uv run alembic upgrade head`
 to create the latest database tables and indices for the database.
 
-**In development**: To start the FastAPI rest server in dev mode:
+**🛠️ In development (Non Dockerized)**: To start the FastAPI rest server in dev mode:
+> ⚠️ Note: This method only runs the api server and not the supporting services in docker (keycloak, nginx, etc.)
+> [Recommended: Run with Docker](#Running Locally with Docker)
+
 1. Run `export DATABASE_URL=postgresql://bluecore_admin:bluecore_admin@localhost/bluecore` to add the needed environmental variable 
 2. Run the application at *http://localhost:3000*
 `uv run fastapi dev src/bluecore/app/main.py --port 3000`
@@ -63,10 +66,27 @@ This is in development mode and code changes will immediately be loaded without 
 ---
 
 ## 👨‍💻 Developers
+### 🐳 Running Locally with Docker
+Dev Docker compose file needs to be specified when starting the container service.
+
+```bash
+docker compose -f compose-dev.yaml up
+```
+### 🚧 Accessing App
+Local development URL:
+>  - http://localhost
+
+
 
 ### 🔐 Bypassing Keycloak 
-To access the API without needing to authenticate with Keycloak: 
-* run `export BYPASS_KEYCLOAK=true` before running the application.
+To access the API without needing the API to authenticate with Keycloak: 
+* Uncomment `BYPASS_KEYCLOAK: "true"` in `compose-dev.yaml`
+
+### 🔑 Logging into Keycloak master realm
+You can also create a new realm and client in Keycloak by going to:
+> - http://localhost/keycloak 
+> - username: `admin` 
+> - password: `gracious-professed`
 
 ### 🧹 Linter for Python 
 Bluecore API uses [ruff](https://docs.astral.sh/ruff/)

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ This is in development mode and code changes will immediately be loaded without 
 
 ### 🔐 Bypassing Keycloak 
 To access the API without needing to authenticate with Keycloak: 
-* run `export DEVELOPER_MODE=true` before running the application.
+* run `export BYPASS_KEYCLOAK=true` before running the application.
 
 ### 🧹 Linter for Python 
 Bluecore API uses [ruff](https://docs.astral.sh/ruff/)

--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -1,0 +1,38 @@
+services:
+  bluecore-store:
+    image: pgvector/pgvector:pg17
+    environment:
+      POSTGRES_USER: bluecore_admin
+      POSTGRES_PASSWORD: bluecore_admin
+      POSTGRES_DB: bluecore
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-db-volume:/var/lib/postgresql/data
+      - ./create-db.sql:/docker-entrypoint-initdb.d/create_database.sql
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "bluecore_admin"]
+      interval: 10s
+      retries: 5
+      start_period: 5s
+    restart: always
+
+  bc_api:
+    build:
+      context: .
+      dockerfile: Dockerfile-dev
+    depends_on:
+      bluecore-store:
+        condition: service_healthy
+    ports:
+      - "8100:8100"
+    volumes:
+      - .:/app
+    environment:
+      UV_CACHE_DIR: /tmp/uv-cache
+      DATABASE_URL: postgresql+psycopg2://bluecore_admin:bluecore_admin@bluecore-store:5432/bluecore
+      DEVELOPER_MODE: "true"
+    command: ["uv", "run", "fastapi", "run", "src/bluecore/app/main.py", "--port", "8100", "--root-path", "/api"]
+
+volumes:
+  postgres-db-volume:

--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -54,8 +54,8 @@ services:
     depends_on:
       bluecore-store:
         condition: service_healthy
-    ports:
-      - "8100:8100"
+    expose:
+      - 8100
     volumes:
       - .:/app
     environment:
@@ -73,8 +73,9 @@ services:
     depends_on:
       bluecore-store:
         condition: service_healthy
-    ports:
-      - "8081:8080"
+    expose:
+      - 8080
+      - 8443
     volumes:
       - ./keycloak-export/bluecore-realm.json:/opt/keycloak/data/import/realm.json
       - ./keycloak-export/:/opt/keycloak/data/export
@@ -84,6 +85,15 @@ services:
       timeout: 10s
       retries: 20
     restart: always
+
+  nginx:
+    restart: always
+    build:
+      context: ./nginx
+    ports:
+      - "80:80"
+    depends_on:
+      - keycloak
 
 volumes:
   postgres-db-volume:

--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -63,7 +63,6 @@ services:
       UV_CACHE_DIR: /tmp/uv-cache
       DATABASE_URL: postgresql+psycopg2://bluecore_admin:bluecore_admin@bluecore-store:5432/bluecore
       #BYPASS_KEYCLOAK: "true" # Uncomment this line to bypass keycloak authentication
-    command: ["uv", "run", "fastapi", "dev", "src/bluecore/app/main.py", "--host", "0.0.0.0", "--port", "8100", "--root-path", "/api"]
 
   keycloak:
     image: quay.io/keycloak/keycloak:26.1.2

--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -6,7 +6,7 @@ x-keycloak-env: &keycloak-env
   KEYCLOAK_REALM: 'bluecore'
   # ----- Master realm Admin credentials ---------------
   KEYCLOAK_ADMIN: admin
-  KEYCLOAK_ADMIN_PASSWORD: admin
+  KEYCLOAK_ADMIN_PASSWORD: gracious-professed
   # ----- Keycloak database connection -----------------
   KC_DB: postgres
   KC_DB_SCHEMA: public

--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -1,15 +1,45 @@
+x-keycloak-env: &keycloak-env
+  ####################################
+  ## Keycloak Environment Variables ##
+  ####################################
+  # ----- Bluecore realm and keycloak path -------------
+  KEYCLOAK_REALM: 'bluecore'
+  # ----- Master realm Admin credentials ---------------
+  KEYCLOAK_ADMIN: admin
+  KEYCLOAK_ADMIN_PASSWORD: admin
+  # ----- Keycloak database connection -----------------
+  KC_DB: postgres
+  KC_DB_SCHEMA: public
+  KC_DB_URL_HOST: bluecore-store
+  KC_DB_URL_PORT: 5432
+  KC_DB_URL_DATABASE: keycloak
+  KC_DB_USERNAME: bluecore_admin
+  KC_DB_PASSWORD: bluecore_admin
+  # ----- Keycloak health check enabled -----------------
+  KC_HEALTH_ENABLED: 'true'
+  # ----- Keycloak HTTP and proxy access settings -------
+  KEYCLOAK_URL: 'http://keycloak:8080/keycloak'
+  KC_HOSTNAME_STRICT: "false"
+  API_KEYCLOAK_CLIENT_ID: 'bluecore_api'
+  API_KEYCLOAK_CLIENT_SECRET: 'K0b2aBJlqDFcTiozMTP5XM6vf2G9E18W'
+  KC_PROXY_HEADERS: 'xforwarded'
+  KC_PROXY: 'edge'
+  KC_HTTP_ENABLED: 'true'
+  KC_HTTP_RELATIVE_PATH: '/keycloak/'
+  KC_LOG_LEVEL: 'INFO'
+
 services:
   bluecore-store:
     image: pgvector/pgvector:pg17
     environment:
       POSTGRES_USER: bluecore_admin
       POSTGRES_PASSWORD: bluecore_admin
-      POSTGRES_DB: bluecore
+      POSTGRES_MULTIPLE_DB: bluecore, keycloak
     ports:
       - "5432:5432"
     volumes:
       - postgres-db-volume:/var/lib/postgresql/data
-      - ./create-db.sql:/docker-entrypoint-initdb.d/create_database.sql
+      - ./scripts/init-multi-postgres-dbs.sh:/docker-entrypoint-initdb.d/init-multi-postgres-dbs.sh
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "bluecore_admin"]
       interval: 10s
@@ -29,10 +59,31 @@ services:
     volumes:
       - .:/app
     environment:
+      <<: *keycloak-env
       UV_CACHE_DIR: /tmp/uv-cache
       DATABASE_URL: postgresql+psycopg2://bluecore_admin:bluecore_admin@bluecore-store:5432/bluecore
-      DEVELOPER_MODE: "true"
+#      DEVELOPER_MODE: "true"
     command: ["uv", "run", "fastapi", "run", "src/bluecore/app/main.py", "--port", "8100", "--root-path", "/api"]
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.1.2
+    command: start-dev  --import-realm
+    environment:
+      <<: *keycloak-env
+    depends_on:
+      bluecore-store:
+        condition: service_healthy
+    ports:
+      - "8081:8080"
+    volumes:
+      - ./keycloak-export/bluecore-realm.json:/opt/keycloak/data/import/realm.json
+      - ./keycloak-export/:/opt/keycloak/data/export
+    healthcheck:
+      test: ["CMD-SHELL", "exec 3<> /dev/tcp/127.0.0.1/9000; echo -e 'GET /health/ready HTTP/1.1\\r\\nhost: http://localhost\\r\\nConnection: close\\r\\n\\r\\n' >&3; if [ $? -eq 0 ]; then echo 'Healthcheck Successful'; exit 0; else echo 'Healthcheck Failed'; exit 1; fi;"]
+      interval: 10s
+      timeout: 10s
+      retries: 20
+    restart: always
 
 volumes:
   postgres-db-volume:

--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -62,7 +62,7 @@ services:
       <<: *keycloak-env
       UV_CACHE_DIR: /tmp/uv-cache
       DATABASE_URL: postgresql+psycopg2://bluecore_admin:bluecore_admin@bluecore-store:5432/bluecore
-#      DEVELOPER_MODE: "true"
+      #BYPASS_KEYCLOAK: "true" # Uncomment this line to bypass keycloak authentication
     command: ["uv", "run", "fastapi", "run", "src/bluecore/app/main.py", "--port", "8100", "--root-path", "/api"]
 
   keycloak:

--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -63,7 +63,7 @@ services:
       UV_CACHE_DIR: /tmp/uv-cache
       DATABASE_URL: postgresql+psycopg2://bluecore_admin:bluecore_admin@bluecore-store:5432/bluecore
       #BYPASS_KEYCLOAK: "true" # Uncomment this line to bypass keycloak authentication
-    command: ["uv", "run", "fastapi", "run", "src/bluecore/app/main.py", "--port", "8100", "--root-path", "/api"]
+    command: ["uv", "run", "fastapi", "dev", "src/bluecore/app/main.py", "--host", "0.0.0.0", "--port", "8100", "--root-path", "/api"]
 
   keycloak:
     image: quay.io/keycloak/keycloak:26.1.2

--- a/keycloak-export/bluecore-realm.json
+++ b/keycloak-export/bluecore-realm.json
@@ -1,0 +1,2312 @@
+{
+  "id" : "19fb378d-99ba-452e-b722-b5508ca29427",
+  "realm" : "bluecore",
+  "notBefore" : 0,
+  "defaultSignatureAlgorithm" : "RS256",
+  "revokeRefreshToken" : false,
+  "refreshTokenMaxReuse" : 0,
+  "accessTokenLifespan" : 300,
+  "accessTokenLifespanForImplicitFlow" : 900,
+  "ssoSessionIdleTimeout" : 1800,
+  "ssoSessionMaxLifespan" : 36000,
+  "ssoSessionIdleTimeoutRememberMe" : 0,
+  "ssoSessionMaxLifespanRememberMe" : 0,
+  "offlineSessionIdleTimeout" : 2592000,
+  "offlineSessionMaxLifespanEnabled" : false,
+  "offlineSessionMaxLifespan" : 5184000,
+  "clientSessionIdleTimeout" : 0,
+  "clientSessionMaxLifespan" : 0,
+  "clientOfflineSessionIdleTimeout" : 0,
+  "clientOfflineSessionMaxLifespan" : 0,
+  "accessCodeLifespan" : 60,
+  "accessCodeLifespanUserAction" : 300,
+  "accessCodeLifespanLogin" : 1800,
+  "actionTokenGeneratedByAdminLifespan" : 43200,
+  "actionTokenGeneratedByUserLifespan" : 300,
+  "oauth2DeviceCodeLifespan" : 600,
+  "oauth2DevicePollingInterval" : 5,
+  "enabled" : true,
+  "sslRequired" : "external",
+  "registrationAllowed" : false,
+  "registrationEmailAsUsername" : false,
+  "rememberMe" : false,
+  "verifyEmail" : false,
+  "loginWithEmailAllowed" : true,
+  "duplicateEmailsAllowed" : false,
+  "resetPasswordAllowed" : false,
+  "editUsernameAllowed" : false,
+  "bruteForceProtected" : false,
+  "permanentLockout" : false,
+  "maxTemporaryLockouts" : 0,
+  "bruteForceStrategy" : "MULTIPLE",
+  "maxFailureWaitSeconds" : 900,
+  "minimumQuickLoginWaitSeconds" : 60,
+  "waitIncrementSeconds" : 60,
+  "quickLoginCheckMilliSeconds" : 1000,
+  "maxDeltaTimeSeconds" : 43200,
+  "failureFactor" : 30,
+  "roles" : {
+    "realm" : [ {
+      "id" : "4439495f-0b81-401c-bae6-e7172a0f989e",
+      "name" : "uma_authorization",
+      "description" : "${role_uma_authorization}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "19fb378d-99ba-452e-b722-b5508ca29427",
+      "attributes" : { }
+    }, {
+      "id" : "d8d79407-e826-45db-af28-e1e70906fe02",
+      "name" : "default-roles-bluecore",
+      "description" : "${role_default-roles}",
+      "composite" : true,
+      "composites" : {
+        "realm" : [ "offline_access", "uma_authorization" ],
+        "client" : {
+          "account" : [ "manage-account", "view-profile" ]
+        }
+      },
+      "clientRole" : false,
+      "containerId" : "19fb378d-99ba-452e-b722-b5508ca29427",
+      "attributes" : { }
+    }, {
+      "id" : "367b6525-2259-4259-bd08-b486bac76dfb",
+      "name" : "create",
+      "description" : "",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "19fb378d-99ba-452e-b722-b5508ca29427",
+      "attributes" : { }
+    }, {
+      "id" : "5be31477-c788-4386-8e69-07125a67f280",
+      "name" : "offline_access",
+      "description" : "${role_offline-access}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "19fb378d-99ba-452e-b722-b5508ca29427",
+      "attributes" : { }
+    }, {
+      "id" : "13e4436d-54de-4ab7-8ce0-8a488d054c12",
+      "name" : "update",
+      "description" : "",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "19fb378d-99ba-452e-b722-b5508ca29427",
+      "attributes" : { }
+    } ],
+    "client" : {
+      "realm-management" : [ {
+        "id" : "d8ec2115-49d5-4e0c-b525-b209dbd0f4e3",
+        "name" : "manage-realm",
+        "description" : "${role_manage-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f8f1754f-84ee-411a-b889-85f3330933ce",
+        "attributes" : { }
+      }, {
+        "id" : "5612e636-c4cd-4793-a30e-13853b5ca365",
+        "name" : "query-groups",
+        "description" : "${role_query-groups}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f8f1754f-84ee-411a-b889-85f3330933ce",
+        "attributes" : { }
+      }, {
+        "id" : "5c3bf6b3-744c-4bf3-839b-5b30fa633708",
+        "name" : "manage-authorization",
+        "description" : "${role_manage-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f8f1754f-84ee-411a-b889-85f3330933ce",
+        "attributes" : { }
+      }, {
+        "id" : "c3c16e0e-f345-46c4-98d7-6982c7e81684",
+        "name" : "create-client",
+        "description" : "${role_create-client}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f8f1754f-84ee-411a-b889-85f3330933ce",
+        "attributes" : { }
+      }, {
+        "id" : "74ed7160-742e-468a-ab00-76cf5dcf9564",
+        "name" : "view-authorization",
+        "description" : "${role_view-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f8f1754f-84ee-411a-b889-85f3330933ce",
+        "attributes" : { }
+      }, {
+        "id" : "f1658169-5991-4eb0-b78c-2ecb51a175ca",
+        "name" : "manage-identity-providers",
+        "description" : "${role_manage-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f8f1754f-84ee-411a-b889-85f3330933ce",
+        "attributes" : { }
+      }, {
+        "id" : "b5eaf812-0792-4553-ab46-28359a6df70e",
+        "name" : "view-users",
+        "description" : "${role_view-users}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-groups", "query-users" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "f8f1754f-84ee-411a-b889-85f3330933ce",
+        "attributes" : { }
+      }, {
+        "id" : "06e7df17-a148-44a7-b170-cb684a409dcc",
+        "name" : "realm-admin",
+        "description" : "${role_realm-admin}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "manage-realm", "query-groups", "manage-authorization", "create-client", "view-authorization", "manage-identity-providers", "view-users", "view-events", "query-clients", "manage-users", "query-realms", "view-identity-providers", "manage-clients", "query-users", "impersonation", "manage-events", "view-realm", "view-clients" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "f8f1754f-84ee-411a-b889-85f3330933ce",
+        "attributes" : { }
+      }, {
+        "id" : "01895268-3f59-47cb-b875-38f34420b26a",
+        "name" : "view-events",
+        "description" : "${role_view-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f8f1754f-84ee-411a-b889-85f3330933ce",
+        "attributes" : { }
+      }, {
+        "id" : "e5bb9631-90ac-4545-bfb0-a52de1f9f924",
+        "name" : "query-clients",
+        "description" : "${role_query-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f8f1754f-84ee-411a-b889-85f3330933ce",
+        "attributes" : { }
+      }, {
+        "id" : "2f999baa-41f0-4276-8d91-824082029bea",
+        "name" : "manage-users",
+        "description" : "${role_manage-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f8f1754f-84ee-411a-b889-85f3330933ce",
+        "attributes" : { }
+      }, {
+        "id" : "4ca21318-bcb0-4a5c-b1fb-98498bfbf20b",
+        "name" : "query-realms",
+        "description" : "${role_query-realms}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f8f1754f-84ee-411a-b889-85f3330933ce",
+        "attributes" : { }
+      }, {
+        "id" : "ea27844d-8bd4-456f-ab97-2d22ea113ad3",
+        "name" : "view-identity-providers",
+        "description" : "${role_view-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f8f1754f-84ee-411a-b889-85f3330933ce",
+        "attributes" : { }
+      }, {
+        "id" : "f1f16640-87b8-4314-a3e8-648d2699edd4",
+        "name" : "manage-clients",
+        "description" : "${role_manage-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f8f1754f-84ee-411a-b889-85f3330933ce",
+        "attributes" : { }
+      }, {
+        "id" : "2cb9986e-ff42-43a3-8693-622c0419eb73",
+        "name" : "query-users",
+        "description" : "${role_query-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f8f1754f-84ee-411a-b889-85f3330933ce",
+        "attributes" : { }
+      }, {
+        "id" : "c916b672-d9ba-4963-846d-90b8876e0918",
+        "name" : "impersonation",
+        "description" : "${role_impersonation}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f8f1754f-84ee-411a-b889-85f3330933ce",
+        "attributes" : { }
+      }, {
+        "id" : "5acac0a3-51ce-478d-b728-d1fc7eedef2e",
+        "name" : "manage-events",
+        "description" : "${role_manage-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f8f1754f-84ee-411a-b889-85f3330933ce",
+        "attributes" : { }
+      }, {
+        "id" : "3dec7127-ee2e-4c3b-a9d3-d79f395fce31",
+        "name" : "view-realm",
+        "description" : "${role_view-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f8f1754f-84ee-411a-b889-85f3330933ce",
+        "attributes" : { }
+      }, {
+        "id" : "44be3d42-d1d0-426a-be5a-e7486c2e728a",
+        "name" : "view-clients",
+        "description" : "${role_view-clients}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-clients" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "f8f1754f-84ee-411a-b889-85f3330933ce",
+        "attributes" : { }
+      } ],
+      "bluecore_workflows" : [ {
+        "id" : "0525e7a7-f287-4270-b8e1-4e765530be18",
+        "name" : "airflow_op",
+        "description" : "Op permissions",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "42a30c61-4264-491c-9f62-a5b73485ec85",
+        "attributes" : { }
+      }, {
+        "id" : "eaca3924-c4fa-4394-a4d7-14552e8fac2e",
+        "name" : "update",
+        "description" : "",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "42a30c61-4264-491c-9f62-a5b73485ec85",
+        "attributes" : { }
+      }, {
+        "id" : "8a2d1f37-4d88-41c9-8694-4ab78bca2b54",
+        "name" : "airflow_admin",
+        "description" : "",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "42a30c61-4264-491c-9f62-a5b73485ec85",
+        "attributes" : { }
+      }, {
+        "id" : "c888752b-30a2-4241-8711-26e9c4e72e50",
+        "name" : "airflow_viewer",
+        "description" : "Viewer permissions",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "42a30c61-4264-491c-9f62-a5b73485ec85",
+        "attributes" : { }
+      }, {
+        "id" : "6d43d813-1610-4368-b74c-cd5e356879db",
+        "name" : "airflow_user",
+        "description" : "User permissions",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "42a30c61-4264-491c-9f62-a5b73485ec85",
+        "attributes" : { }
+      }, {
+        "id" : "6e85ccd8-b314-418c-9714-e54589c962fb",
+        "name" : "airflow_public",
+        "description" : "Pubic permissions",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "42a30c61-4264-491c-9f62-a5b73485ec85",
+        "attributes" : { }
+      }, {
+        "id" : "9e22bf43-5826-4822-9825-95149cc46499",
+        "name" : "create",
+        "description" : "",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "42a30c61-4264-491c-9f62-a5b73485ec85",
+        "attributes" : { }
+      } ],
+      "security-admin-console" : [ ],
+      "admin-cli" : [ ],
+      "account-console" : [ ],
+      "broker" : [ {
+        "id" : "a599c43a-ab94-46fd-9e7a-149604acd0a7",
+        "name" : "read-token",
+        "description" : "${role_read-token}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "add916fd-7160-49b9-8363-9f18d1d71f7d",
+        "attributes" : { }
+      } ],
+      "bluecore_api" : [ ],
+      "account" : [ {
+        "id" : "43db9377-5076-408d-894c-75b48b652e5e",
+        "name" : "manage-consent",
+        "description" : "${role_manage-consent}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "view-consent" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "e97b46f0-1d81-4521-92dd-399d8dd435c7",
+        "attributes" : { }
+      }, {
+        "id" : "0085e081-a7f0-49b2-89a0-8f04e77ea79d",
+        "name" : "view-consent",
+        "description" : "${role_view-consent}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "e97b46f0-1d81-4521-92dd-399d8dd435c7",
+        "attributes" : { }
+      }, {
+        "id" : "9032545b-0a06-4056-bcbb-f827b3843ffd",
+        "name" : "manage-account-links",
+        "description" : "${role_manage-account-links}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "e97b46f0-1d81-4521-92dd-399d8dd435c7",
+        "attributes" : { }
+      }, {
+        "id" : "cfa3f0ae-c6d5-4541-92a1-e2015126a395",
+        "name" : "view-applications",
+        "description" : "${role_view-applications}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "e97b46f0-1d81-4521-92dd-399d8dd435c7",
+        "attributes" : { }
+      }, {
+        "id" : "541d6686-1a71-452d-a641-1feb32212451",
+        "name" : "manage-account",
+        "description" : "${role_manage-account}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "manage-account-links" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "e97b46f0-1d81-4521-92dd-399d8dd435c7",
+        "attributes" : { }
+      }, {
+        "id" : "d583998c-5a67-4080-b080-a872b8f91a0e",
+        "name" : "view-profile",
+        "description" : "${role_view-profile}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "e97b46f0-1d81-4521-92dd-399d8dd435c7",
+        "attributes" : { }
+      }, {
+        "id" : "ced1d358-c3e5-42f1-9702-3054e05c5939",
+        "name" : "delete-account",
+        "description" : "${role_delete-account}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "e97b46f0-1d81-4521-92dd-399d8dd435c7",
+        "attributes" : { }
+      }, {
+        "id" : "1d8e7f3e-6f2c-41f6-a493-12301390268c",
+        "name" : "view-groups",
+        "description" : "${role_view-groups}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "e97b46f0-1d81-4521-92dd-399d8dd435c7",
+        "attributes" : { }
+      } ]
+    }
+  },
+  "groups" : [ ],
+  "defaultRole" : {
+    "id" : "d8d79407-e826-45db-af28-e1e70906fe02",
+    "name" : "default-roles-bluecore",
+    "description" : "${role_default-roles}",
+    "composite" : true,
+    "clientRole" : false,
+    "containerId" : "19fb378d-99ba-452e-b722-b5508ca29427"
+  },
+  "requiredCredentials" : [ "password" ],
+  "otpPolicyType" : "totp",
+  "otpPolicyAlgorithm" : "HmacSHA1",
+  "otpPolicyInitialCounter" : 0,
+  "otpPolicyDigits" : 6,
+  "otpPolicyLookAheadWindow" : 1,
+  "otpPolicyPeriod" : 30,
+  "otpPolicyCodeReusable" : false,
+  "otpSupportedApplications" : [ "totpAppFreeOTPName", "totpAppGoogleName", "totpAppMicrosoftAuthenticatorName" ],
+  "localizationTexts" : { },
+  "webAuthnPolicyRpEntityName" : "keycloak",
+  "webAuthnPolicySignatureAlgorithms" : [ "ES256", "RS256" ],
+  "webAuthnPolicyRpId" : "",
+  "webAuthnPolicyAttestationConveyancePreference" : "not specified",
+  "webAuthnPolicyAuthenticatorAttachment" : "not specified",
+  "webAuthnPolicyRequireResidentKey" : "not specified",
+  "webAuthnPolicyUserVerificationRequirement" : "not specified",
+  "webAuthnPolicyCreateTimeout" : 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister" : false,
+  "webAuthnPolicyAcceptableAaguids" : [ ],
+  "webAuthnPolicyExtraOrigins" : [ ],
+  "webAuthnPolicyPasswordlessRpEntityName" : "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms" : [ "ES256", "RS256" ],
+  "webAuthnPolicyPasswordlessRpId" : "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference" : "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment" : "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey" : "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement" : "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout" : 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister" : false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids" : [ ],
+  "webAuthnPolicyPasswordlessExtraOrigins" : [ ],
+  "users" : [ {
+    "id" : "55875c9a-c67c-4c60-9c91-bc260f71f92a",
+    "username" : "developer",
+    "firstName" : "Johny",
+    "lastName" : "Dev",
+    "email" : "johnydev@bluecore.edu",
+    "emailVerified" : true,
+    "createdTimestamp" : 1746805392682,
+    "enabled" : true,
+    "totp" : false,
+    "credentials" : [ {
+      "id" : "62e06c30-616d-43c1-907c-c87f05b50472",
+      "type" : "password",
+      "userLabel" : "My password",
+      "createdDate" : 1746919916827,
+      "secretData" : "{\"value\":\"stLMwnG/Jm5C/eXM29DI9IfeGZeKX79pFbjsS1SWeyc=\",\"salt\":\"uXhdy+1enjTD//yif9nQYg==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-bluecore", "create", "update" ],
+    "clientRoles" : {
+      "bluecore_workflows" : [ "update", "airflow_admin", "create" ]
+    },
+    "notBefore" : 0,
+    "groups" : [ ]
+  }, {
+    "id" : "dceb2a20-74a0-480d-96fa-e92c0a06ffec",
+    "username" : "dev_op",
+    "firstName" : "dev",
+    "lastName" : "op",
+    "email" : "dev_op@bluecore.edu",
+    "emailVerified" : true,
+    "createdTimestamp" : 1746926159620,
+    "enabled" : true,
+    "totp" : false,
+    "credentials" : [ {
+      "id" : "54428d66-02e1-4e75-bbf0-83e848faa487",
+      "type" : "password",
+      "userLabel" : "My password",
+      "createdDate" : 1746926336258,
+      "secretData" : "{\"value\":\"sP30MoZjaCJhhgBvsqitKw4fhErI29k3SpKcv61SFWI=\",\"salt\":\"6vTTyObSeYuNV7iJK0iCHw==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-bluecore" ],
+    "clientRoles" : {
+      "bluecore_workflows" : [ "airflow_op" ]
+    },
+    "notBefore" : 0,
+    "groups" : [ ]
+  }, {
+    "id" : "dc33ec60-68e0-468e-bf23-3c41522832b4",
+    "username" : "dev_public",
+    "firstName" : "dev",
+    "lastName" : "public",
+    "email" : "dev_public@bluecore.edu",
+    "emailVerified" : true,
+    "createdTimestamp" : 1746926529473,
+    "enabled" : true,
+    "totp" : false,
+    "credentials" : [ {
+      "id" : "0725e74c-b248-4da5-b362-0150a374c5d4",
+      "type" : "password",
+      "userLabel" : "My password",
+      "createdDate" : 1746926561741,
+      "secretData" : "{\"value\":\"JdsaMgRxaGejVeR7AsEyuuI1lSD/Xm5KOkzRJ4H8wS0=\",\"salt\":\"EQg6yKw6nCbr104LxXHtUw==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-bluecore" ],
+    "clientRoles" : {
+      "bluecore_workflows" : [ "airflow_public" ]
+    },
+    "notBefore" : 0,
+    "groups" : [ ]
+  }, {
+    "id" : "a7c542ab-7b25-4148-8917-b8bb0198da8b",
+    "username" : "dev_user",
+    "firstName" : "dev",
+    "lastName" : "user",
+    "email" : "dev_user@bluecore.edu",
+    "emailVerified" : true,
+    "createdTimestamp" : 1746926440735,
+    "enabled" : true,
+    "totp" : false,
+    "credentials" : [ {
+      "id" : "b7d83078-ae36-4802-8ad6-123171209e8f",
+      "type" : "password",
+      "userLabel" : "My password",
+      "createdDate" : 1746926596404,
+      "secretData" : "{\"value\":\"hkejPyJknD07+KHaoFORh0hhIetuduJYXxEmmZSS3AM=\",\"salt\":\"O1S6yEKQEutwgkyOh6lHdw==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-bluecore" ],
+    "clientRoles" : {
+      "bluecore_workflows" : [ "airflow_user" ]
+    },
+    "notBefore" : 0,
+    "groups" : [ ]
+  }, {
+    "id" : "f12592c6-973e-4fc0-8547-87816eddc559",
+    "username" : "dev_viewer",
+    "firstName" : "dev",
+    "lastName" : "viewer",
+    "email" : "dev_viewer@bluecore.edu",
+    "emailVerified" : true,
+    "createdTimestamp" : 1746926486945,
+    "enabled" : true,
+    "totp" : false,
+    "credentials" : [ {
+      "id" : "73231013-d210-4d46-bf77-f01c52e417ea",
+      "type" : "password",
+      "userLabel" : "My password",
+      "createdDate" : 1746926613337,
+      "secretData" : "{\"value\":\"2pFCZqyDVdBdrV4L0TJQM9Nybe0irxTNWJcQAt123m0=\",\"salt\":\"h4+P35X1JrN2/lPBedci9Q==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-bluecore" ],
+    "clientRoles" : {
+      "bluecore_workflows" : [ "airflow_viewer" ]
+    },
+    "notBefore" : 0,
+    "groups" : [ ]
+  } ],
+  "scopeMappings" : [ {
+    "clientScope" : "offline_access",
+    "roles" : [ "offline_access" ]
+  } ],
+  "clientScopeMappings" : {
+    "account" : [ {
+      "client" : "account-console",
+      "roles" : [ "manage-account", "view-groups" ]
+    } ]
+  },
+  "clients" : [ {
+    "id" : "e97b46f0-1d81-4521-92dd-399d8dd435c7",
+    "clientId" : "account",
+    "name" : "${client_account}",
+    "rootUrl" : "${authBaseUrl}",
+    "baseUrl" : "/realms/bluecore/account/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/realms/bluecore/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "false",
+      "post.logout.redirect.uris" : "+"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "organization", "microprofile-jwt" ]
+  }, {
+    "id" : "a9d6ce1c-0645-418d-8fd4-3b8180e5e26d",
+    "clientId" : "account-console",
+    "name" : "${client_account-console}",
+    "rootUrl" : "${authBaseUrl}",
+    "baseUrl" : "/realms/bluecore/account/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/realms/bluecore/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "false",
+      "post.logout.redirect.uris" : "+",
+      "pkce.code.challenge.method" : "S256"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "c47b7e9a-e9db-4a18-823a-e95ff9931e64",
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "organization", "microprofile-jwt" ]
+  }, {
+    "id" : "3e16c19e-5d00-43cd-a268-339328a841fb",
+    "clientId" : "admin-cli",
+    "name" : "${client_admin-cli}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : false,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "false",
+      "client.use.lightweight.access.token.enabled" : "true",
+      "post.logout.redirect.uris" : "+"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "organization", "microprofile-jwt" ]
+  }, {
+    "id" : "46668364-93ca-416e-98d7-687a202d96b6",
+    "clientId" : "bluecore_api",
+    "name" : "Bluecore API",
+    "description" : "For API",
+    "rootUrl" : "",
+    "adminUrl" : "",
+    "baseUrl" : "",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "K0b2aBJlqDFcTiozMTP5XM6vf2G9E18W",
+    "redirectUris" : [ "http://localhost/api/oauth-authorized/keycloak", "http://localhost:8080/oauth-authorized/keycloak" ],
+    "webOrigins" : [ "/*" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : true,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "false",
+      "oidc.ciba.grant.enabled" : "false",
+      "client.secret.creation.time" : "1747168703",
+      "backchannel.logout.session.required" : "true",
+      "frontchannel.logout.session.required" : "true",
+      "post.logout.redirect.uris" : "+",
+      "display.on.consent.screen" : "false",
+      "oauth2.device.authorization.grant.enabled" : "false",
+      "backchannel.logout.revoke.offline.tokens" : "false"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "organization", "microprofile-jwt" ]
+  }, {
+    "id" : "42a30c61-4264-491c-9f62-a5b73485ec85",
+    "clientId" : "bluecore_workflows",
+    "name" : "Bluecore Workflows",
+    "description" : "For Airflow",
+    "rootUrl" : "",
+    "adminUrl" : "",
+    "baseUrl" : "",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "KIu8gWa8rtjlT0Zl7zkNzsObFZGJ2IsJ",
+    "redirectUris" : [ "http://localhost/workflows/oauth-authorized/keycloak" ],
+    "webOrigins" : [ "/*" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : true,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "false",
+      "oidc.ciba.grant.enabled" : "false",
+      "client.secret.creation.time" : "1746805333",
+      "backchannel.logout.session.required" : "true",
+      "frontchannel.logout.session.required" : "true",
+      "post.logout.redirect.uris" : "+",
+      "display.on.consent.screen" : "false",
+      "oauth2.device.authorization.grant.enabled" : "false",
+      "backchannel.logout.revoke.offline.tokens" : "false"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "3531de7e-c7d3-4a6e-ba2c-33ad62029584",
+      "name" : "bluecore_workflows",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "included.client.audience" : "bluecore_workflows",
+        "id.token.claim" : "true",
+        "lightweight.claim" : "false",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true",
+        "userinfo.token.claim" : "true"
+      }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "organization", "microprofile-jwt" ]
+  }, {
+    "id" : "add916fd-7160-49b9-8363-9f18d1d71f7d",
+    "clientId" : "broker",
+    "name" : "${client_broker}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "true",
+      "post.logout.redirect.uris" : "+"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "organization", "microprofile-jwt" ]
+  }, {
+    "id" : "f8f1754f-84ee-411a-b889-85f3330933ce",
+    "clientId" : "realm-management",
+    "name" : "${client_realm-management}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "true",
+      "post.logout.redirect.uris" : "+"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "organization", "microprofile-jwt" ]
+  }, {
+    "id" : "a846c58a-a06a-452d-a0a6-2cfd58a284c3",
+    "clientId" : "security-admin-console",
+    "name" : "${client_security-admin-console}",
+    "rootUrl" : "${authAdminUrl}",
+    "baseUrl" : "/admin/bluecore/console/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/admin/bluecore/console/*" ],
+    "webOrigins" : [ "+" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "false",
+      "client.use.lightweight.access.token.enabled" : "true",
+      "post.logout.redirect.uris" : "+",
+      "pkce.code.challenge.method" : "S256"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "5766aea5-f980-46c4-839f-2b513aa619c7",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "organization", "microprofile-jwt" ]
+  } ],
+  "clientScopes" : [ {
+    "id" : "70ecf081-2b4e-46af-bf8e-8b3c1a79cb06",
+    "name" : "saml_organization",
+    "description" : "Organization Membership",
+    "protocol" : "saml",
+    "attributes" : {
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "b1d2802d-28e0-4088-abd7-98063702e6ef",
+      "name" : "organization",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-organization-membership-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ]
+  }, {
+    "id" : "2448f314-43b4-4780-8f5b-f5a91a06275a",
+    "name" : "offline_access",
+    "description" : "OpenID Connect built-in scope: offline_access",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "consent.screen.text" : "${offlineAccessScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    }
+  }, {
+    "id" : "55a88aaf-0754-4f6e-af4e-950aa05a8168",
+    "name" : "roles",
+    "description" : "OpenID Connect scope for add user roles to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "consent.screen.text" : "${rolesScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "43385f46-d60b-4257-848f-31e43200d28e",
+      "name" : "realm roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "realm_access.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    }, {
+      "id" : "f4923fa5-6725-4488-8834-ee6b22356186",
+      "name" : "client roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-client-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "resource_access.${client_id}.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    }, {
+      "id" : "f20f094b-b3bc-45b8-b860-efdffa040600",
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    } ]
+  }, {
+    "id" : "dd20c4ba-6f42-4fe5-9dba-48718d29bfac",
+    "name" : "microprofile-jwt",
+    "description" : "Microprofile - JWT built-in scope",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "e2b8a3b8-3d56-438f-baa3-ceff62acd282",
+      "name" : "groups",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "multivalued" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "foo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "groups",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "1719804a-0e7f-4a2c-a46a-6c3a0ebb4d9e",
+      "name" : "upn",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "upn",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "1ffd26dc-b35c-4b22-9953-69b7be4dcc2e",
+    "name" : "service_account",
+    "description" : "Specific scope for a client enabled for service accounts",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "bc1c156d-e781-4210-9780-bbad8d7eaadc",
+      "name" : "Client ID",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.session.note" : "client_id",
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "client_id",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "fdba9bbb-66b6-45cc-95ce-7f3d9dd9734f",
+      "name" : "Client Host",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.session.note" : "clientHost",
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "clientHost",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "fadc78b4-7080-4e8a-93f6-6408d76aeaeb",
+      "name" : "Client IP Address",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.session.note" : "clientAddress",
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "clientAddress",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "6bdd9495-7790-4dbd-ad82-598c804e79f6",
+    "name" : "organization",
+    "description" : "Additional claims about the organization a subject belongs to",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "consent.screen.text" : "${organizationScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "86052037-50c8-40c6-9671-43b461cd4abd",
+      "name" : "organization",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-organization-membership-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "multivalued" : "true",
+        "userinfo.token.claim" : "true",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "organization",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "a19f1cdb-3b19-458f-a602-979fc76f33e5",
+    "name" : "phone",
+    "description" : "OpenID Connect built-in scope: phone",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "consent.screen.text" : "${phoneScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "f63d8247-b5ff-4a65-956c-3e7be9e373d3",
+      "name" : "phone number",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumber",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "0c8c47c6-e24c-454e-94cc-80e371c619e7",
+      "name" : "phone number verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumberVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number_verified",
+        "jsonType.label" : "boolean"
+      }
+    } ]
+  }, {
+    "id" : "4403e5df-4a79-4cbf-bfd5-8a41e5f15420",
+    "name" : "role_list",
+    "description" : "SAML role list",
+    "protocol" : "saml",
+    "attributes" : {
+      "consent.screen.text" : "${samlRoleListScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "ce0d363f-d1fb-435c-8cf9-fb97f29c6f77",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    } ]
+  }, {
+    "id" : "54a1762f-c2e1-4eb0-aeaa-016228794807",
+    "name" : "web-origins",
+    "description" : "OpenID Connect scope for add allowed web origins to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "consent.screen.text" : "",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "98d22d34-82ee-4109-8e0d-a1e0622fdfed",
+      "name" : "allowed web origins",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-allowed-origins-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    } ]
+  }, {
+    "id" : "12deb2d4-fc21-485d-a588-487fbdb12040",
+    "name" : "email",
+    "description" : "OpenID Connect built-in scope: email",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "consent.screen.text" : "${emailScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "1e7655c4-4f81-4e05-b7dd-0bfa11b03f72",
+      "name" : "email verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "emailVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email_verified",
+        "jsonType.label" : "boolean"
+      }
+    }, {
+      "id" : "56e389da-ddc0-4f20-b3f1-e7d32ff18975",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "13c04a35-7887-4021-b130-cc968e79b1cf",
+    "name" : "address",
+    "description" : "OpenID Connect built-in scope: address",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "consent.screen.text" : "${addressScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "1eb013a8-c58b-48cf-b92d-f64db68e6586",
+      "name" : "address",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-address-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute.formatted" : "formatted",
+        "user.attribute.country" : "country",
+        "introspection.token.claim" : "true",
+        "user.attribute.postal_code" : "postal_code",
+        "userinfo.token.claim" : "true",
+        "user.attribute.street" : "street",
+        "id.token.claim" : "true",
+        "user.attribute.region" : "region",
+        "access.token.claim" : "true",
+        "user.attribute.locality" : "locality"
+      }
+    } ]
+  }, {
+    "id" : "4f499d71-501f-4d36-8845-1520cf02ca12",
+    "name" : "basic",
+    "description" : "OpenID Connect scope for add all basic claims to the token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "d3c2a576-beb3-43ec-aacb-2cc5fbc8a7d4",
+      "name" : "sub",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-sub-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "3a3d42c9-2046-421d-8ecd-75990a1a9b84",
+      "name" : "auth_time",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.session.note" : "AUTH_TIME",
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "auth_time",
+        "jsonType.label" : "long"
+      }
+    } ]
+  }, {
+    "id" : "e17e8151-df88-4e6a-893d-a0d0ac3a5d76",
+    "name" : "profile",
+    "description" : "OpenID Connect built-in scope: profile",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "consent.screen.text" : "${profileScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "5b2ae12e-28a5-464d-8d29-a8654e0855f5",
+      "name" : "picture",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "picture",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "picture",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "8da87fba-c1c6-471b-8981-b7781c7e8229",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "126b4af2-0326-4393-ac3b-fb0053800d2a",
+      "name" : "zoneinfo",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "zoneinfo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "zoneinfo",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "79755a96-84b4-4b1b-818e-eaeb33360565",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true",
+        "userinfo.token.claim" : "true"
+      }
+    }, {
+      "id" : "2271ed9c-3432-4abb-b2c5-07731bdebbe0",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "ff5d3992-f28d-4937-ace1-7363dae67e69",
+      "name" : "birthdate",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "birthdate",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "birthdate",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "de38ab9d-434f-469b-b028-18515e6f7967",
+      "name" : "middle name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "middleName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "middle_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "30686ff1-8afb-4f5c-8c8d-c607208412ce",
+      "name" : "website",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "website",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "website",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "392935f5-0358-463b-8f0d-c5285e6df4b5",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "86ab8493-0816-484b-90c2-24d562c01d2a",
+      "name" : "gender",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "gender",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "gender",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "eaae8cb2-a3dd-4a8f-93e9-42a20e28c7d9",
+      "name" : "updated at",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "updatedAt",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "updated_at",
+        "jsonType.label" : "long"
+      }
+    }, {
+      "id" : "61578e50-18e6-4617-b876-d5d21240cf79",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "3d477586-2200-418a-bdf1-64c585f7740e",
+      "name" : "nickname",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "nickname",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "nickname",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "bf00249c-b93b-40f1-9b61-d152f9a74203",
+      "name" : "profile",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "profile",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "profile",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "b302332f-8175-4af9-a39e-fe729a333dcf",
+    "name" : "acr",
+    "description" : "OpenID Connect scope for add acr (authentication context class reference) to the token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "fa4b01fa-4e63-4273-bb4e-185e52d8a7c0",
+      "name" : "acr loa level",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-acr-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true",
+        "userinfo.token.claim" : "true"
+      }
+    } ]
+  } ],
+  "defaultDefaultClientScopes" : [ "role_list", "saml_organization", "profile", "email", "roles", "web-origins", "acr", "basic" ],
+  "defaultOptionalClientScopes" : [ "offline_access", "address", "phone", "microprofile-jwt", "organization" ],
+  "browserSecurityHeaders" : {
+    "contentSecurityPolicyReportOnly" : "",
+    "xContentTypeOptions" : "nosniff",
+    "referrerPolicy" : "no-referrer",
+    "xRobotsTag" : "none",
+    "xFrameOptions" : "SAMEORIGIN",
+    "contentSecurityPolicy" : "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "xXSSProtection" : "1; mode=block",
+    "strictTransportSecurity" : "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer" : { },
+  "eventsEnabled" : false,
+  "eventsListeners" : [ "jboss-logging" ],
+  "enabledEventTypes" : [ ],
+  "adminEventsEnabled" : false,
+  "adminEventsDetailsEnabled" : false,
+  "identityProviders" : [ ],
+  "identityProviderMappers" : [ ],
+  "components" : {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy" : [ {
+      "id" : "0b8961bb-3fff-4fe4-8501-3d73210cef78",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "oidc-usermodel-attribute-mapper", "oidc-usermodel-property-mapper", "saml-role-list-mapper", "saml-user-property-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-address-mapper", "oidc-full-name-mapper", "saml-user-attribute-mapper" ]
+      }
+    }, {
+      "id" : "4a3137ea-778d-437c-ab89-cea18d91032a",
+      "name" : "Max Clients Limit",
+      "providerId" : "max-clients",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "max-clients" : [ "200" ]
+      }
+    }, {
+      "id" : "bb5aa6eb-ac30-4372-a58d-3272048768ea",
+      "name" : "Consent Required",
+      "providerId" : "consent-required",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "01168b8d-3aaa-4c5d-9166-2019598f62e8",
+      "name" : "Trusted Hosts",
+      "providerId" : "trusted-hosts",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "host-sending-registration-request-must-match" : [ "true" ],
+        "client-uris-must-match" : [ "true" ]
+      }
+    }, {
+      "id" : "8951982e-a63a-4a40-823d-4d89284aad78",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    }, {
+      "id" : "ecb2ba91-7f7f-4c47-92d6-0f728078d8aa",
+      "name" : "Full Scope Disabled",
+      "providerId" : "scope",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "9319a2c1-79c5-434d-a91e-63c6d88ca642",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "oidc-address-mapper", "oidc-usermodel-attribute-mapper", "oidc-full-name-mapper", "saml-role-list-mapper", "saml-user-attribute-mapper", "oidc-sha256-pairwise-sub-mapper", "saml-user-property-mapper", "oidc-usermodel-property-mapper" ]
+      }
+    }, {
+      "id" : "d2f2ccdf-b76c-4973-89c2-b852171a9d85",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    } ],
+    "org.keycloak.keys.KeyProvider" : [ {
+      "id" : "4adf3e16-fdde-4d59-b7ca-7ac824a35391",
+      "name" : "aes-generated",
+      "providerId" : "aes-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "411fbcaf-2ec1-40bc-98fc-1bd7e8ba8f87" ],
+        "secret" : [ "o9wVwpOGvn87avp1AI1y6g" ],
+        "priority" : [ "100" ]
+      }
+    }, {
+      "id" : "313e7b4d-6589-42ba-954e-3d2f98b79be1",
+      "name" : "rsa-generated",
+      "providerId" : "rsa-generated",
+      "subComponents" : { },
+      "config" : {
+        "privateKey" : [ "MIIEowIBAAKCAQEAtNcb7gyXevsF4CiQQEwKMXfynGDlvTtKnUSWcMiV41+BFv10sIUu2AGcuFvDU/0k/kPbg2hYj//7KlnkkJDv/S6S3dZfCm7KQueVcsQrZJqtPKHi7OBRFOrYbLz/WA2Yh12r7xqdchCP5X3Nx54MOqsgbn4ulIenXqBlA7PHtD/cPG+GsUj1vvzUtZ8WyT0t0E4t70syuImpj+Cx5fFYMPGVMqofX516+mzPJYjHmiVhM+WtzpwSnhwJndPQmYV7R+cmkfPmPHyfwHF+iRU+nKEY+4BToc6Xl1/wgwzZKpp41C3R9pKuNAFbK7964T/NnvdAtH259aHNn6+NfCnJWQIDAQABAoIBABO1UceVZbjdvJvbr9o3WfEJjSOPx9nh/qq5u9ovchkP4ntamf9W3xkOwUFc9sz4zLGikZIhABiJdu+m+6rpsM3wknRMwETceCc8d+QZuaTthS2+HYNf8FY4QJKb3Ql/9HyO2oW6FSibjM3KR8VBKzywQ7ORsDU4Z3wqPM1ffXHeSOHsMmLc6WkA3lxLSQYExtNDmhTRuxVANUkEsYPlBggVtYQogVcDhgVVAS2sq4jWoSOmfTWTEf4bt6+lELVsLhcynLtN4xEf2chnBjk33aoShN+ZJzZ99axhK4/WrvRW4WAPuUhmvqgSlXLhsm31QEoctfNwzxKPU9JaOqfVIyUCgYEA39Ge0pOu/ms1nd6rArm+1CvhuBD0ZDSMYCN1IZo3OQrXYRNjLIXzA2VXDhkW2UHpl3aYIasKsOyW6D1gUntvD2GSWA6Gm2B15pM5bMHED181HG005H3EjlMINStqdljM2+LR6ybcwEDC4RQd0MgzktJLmDTlsbtKBvP10Suy4pMCgYEAzteF6a+vcCHEiXBrnTUZga1SPDHPtReE6HYJ6MIbncPX1lzUglh1RoHM/LnkmJdDTcke01sgOuGkp8YMzYPus487fgy3xaTa/6h2/6U9Uen2L4szBSenM0AbX/qpZQp8/UQXmNxyHPhlkxHkNoqoDXgtcS0FZLyIaauwF/lBO+MCgYACVgG+WOQ+q4fHugc25BFlzX9xmFu0oAfHCRez3hQteDt/O+CRGmTK6EfcUc63PcTeW9KCp3JZHl8E1X8n3Tnvgykv2hb1kDAq0+aJiAwvzOKVBV7D87wVcDBpvaZCzfJ1aQyf06wCJarjBn65Kx2+roszb3nmPPos0GcEY9xeGQKBgD7D+dfavwLozEnkelNfHJlULeMkPmI2e9dKkmE2Hck295UN4FKZYyT9GGYMRsjjBcJh6F+8hEA53owmthXbFiEYsrXiSBXKm8X+qfWTf9MOiu0McXP7/2m251etqZ+Gmj0EX6C8LEiMO85wHG9MjghgUnHIdp2F9GMUfUAZG+l/AoGBAJK0HecOtN0brMPyBUSwRagUw1bKaWL9z36WF0QtCKHQsaCQ+89DKBe8dR9jUuppwQvzbxE+ncSi/T3+FdhfZihHoa7IXsm2BwK1882trpGPrV0SIStHZyVJs00Oa3N/wHL61rQ+3rO3ZSIYeDpn0bfzPY8dFyp2lVJnS9kQjenp" ],
+        "keyUse" : [ "SIG" ],
+        "certificate" : [ "MIICnzCCAYcCBgGWtbWsmDANBgkqhkiG9w0BAQsFADATMREwDwYDVQQDDAhibHVlY29yZTAeFw0yNTA1MDkxNTQwMDRaFw0zNTA1MDkxNTQxNDRaMBMxETAPBgNVBAMMCGJsdWVjb3JlMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtNcb7gyXevsF4CiQQEwKMXfynGDlvTtKnUSWcMiV41+BFv10sIUu2AGcuFvDU/0k/kPbg2hYj//7KlnkkJDv/S6S3dZfCm7KQueVcsQrZJqtPKHi7OBRFOrYbLz/WA2Yh12r7xqdchCP5X3Nx54MOqsgbn4ulIenXqBlA7PHtD/cPG+GsUj1vvzUtZ8WyT0t0E4t70syuImpj+Cx5fFYMPGVMqofX516+mzPJYjHmiVhM+WtzpwSnhwJndPQmYV7R+cmkfPmPHyfwHF+iRU+nKEY+4BToc6Xl1/wgwzZKpp41C3R9pKuNAFbK7964T/NnvdAtH259aHNn6+NfCnJWQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQAhGqtGookl2OuD9oaT5Zl30IAKu4lKQYKItM6ugtqGHgpll8RyQb4NkBVuu7E57csx2xUQULEHi+pC4Mdq2Hg4eTd+w+rY7uLfsxqq/PAAKktvwAKg4KuFCw4s68oebhrRoxfivSAx17niUZPdVffDYXHMKiwSUCRihJ037aKC4YfpOm/6Lv4STBIDW8j1hJxnifOlU6LHQropaKhGN8KEtoGaqv0ZQNZUMYSPjYg/975dEBqi30UIjS1Jbqn6363nVnj+pFqvkbeZjreze8xoyZfKeBaefqxG8sxyESWh5HLkR/inDPtc923aahr58O+IN9RLhq7EitH9ESbd2Npa" ],
+        "priority" : [ "100" ]
+      }
+    }, {
+      "id" : "a57644b6-6ba8-44ff-8a35-83000cc0efab",
+      "name" : "rsa-enc-generated",
+      "providerId" : "rsa-enc-generated",
+      "subComponents" : { },
+      "config" : {
+        "privateKey" : [ "MIIEowIBAAKCAQEAuOz3Ayw72YcVs+P40jbKkjh8DZI7tl8Y74X5h7igpJbdZdYV95ViD0pRdKF5YqzI3GEX+8wSXwU5xspa4dYwTTiW2i2xrodDZiw5R0UOZ5Bi0VQiW1UuVU2H3b2fqGjRInoxwUGuaVvSa4P6dhPr7XpMQjW95U1LSz16fk4oNFhTWLvamLEwHN6qJPd9H486DyE++im4Wnwf/R4UD8Rgpx5Z7criBP66lGYHpwgdIRti68ZTzf++yck8X8wuxuYJ3sLmYd6wdiCXQbZQdASnXkSicKbFGQlXOIqDldzkO5o0D9lAz5ORkF4pjVysxa1c5hjNHxojuH3KEnvfEcIUqwIDAQABAoIBAAGLSw1LeR3ys4Znqw2sBE7F6ZGqLxFmoOiz5hydLcpxH3ojuTxRvqHXI2T7blu6xTeBo9BI6qfW6xLmWUGxjTc9y7InUEP1S0vkrj1qXUHTuPT/P8rDf7+vrmpu+tKQV8eev3g8wIkD0tYO7uODSYdn5/2tMoRMIJz273PZy9jjWJtoZhDM0nAb774J0RDcRZo/YF82i39OYfwi9QZxTa/s3Ul5I8x3RWvVq/2fBuR6JGoz4lkIvuOlGc7KrSWkZ8ya9rGnI723OHmciFJgfucZcGJXscE2Llq2Qb3I0MAaySlYLR+4qurSMKv4hColeAc1tHK+dTKFaFTML4XMn9kCgYEA8ZGhd9rSErWlSiJ6PTeSrmPFIGHq50GeI5hlQ9VnxYekZYIguWT3nOORyjCiXo/UjhNUARiS9iC7EB0Qjs7ztsJMt4NzqLMp3aGz19J4wiDS52mn9gdBW2Fm1q+RbjpNmqaxaR3HtvPNtPuPGe/1D3Ao2PsRZ/7zo3AI3XUhjI0CgYEAw/kTd8Rd1X/UYkDtiuTOynXupHXrj71uwEixlj8FEH19NdmPqQezypWnBjQsfAk772ci5gAtelpjLt0m0pIGopE7QllKNMQT5OcWN6XGe1D8Z4ZdJBuwUKUC7ixoFNgzpACphzLWDCvnsTdcTL2eXvk5KL10Gn/7rzTcGcxNRBcCgYEAkCbbN+54VXnXvLl+QHGdMjuPMpe72WwqtgsGwsfiONmMnJZeeMNrj0+te/4xpkQmDvIxusWzTPSTLDZr3wxYGsMvjIMAzba8UOlhrHSIYy+7KyS9ee8ybRleiNYT7rcUAClgzN1chCxQoKNM7alnj2LavUB1Tp2xPeJpJ93xuzECgYAA+Y41PE7TLw2ZZ4VG+ZhlvWxweP2w+1o/rpzjiHC4AkfLKsfiKV2lllT8XOoTu+AGctbjmgCf6S8xHnyA86UAzgQjclpCJO+MZfHgWPzBxEddJHf2JAUegZOgJ6xk3iZznGU7fO8/pEBEy2e0IgVVp5u3LioTr6tK1dJ6dl+0BQKBgEaqADRGS5hTxG/Nb8edoI4WhWqi4QT8BxIo57Nlvg98fpyW16O21CjIlsVsGfQBgbjbFvaWY2wooWVc37L4XEemJ9ShWTk8rP46eLfu9AdKoV0ny63wUNat3RvO0UAASAYBp0AyAqq+u8ObiMTzBUbALMg03d4V7Hf5EgoIc1w8" ],
+        "keyUse" : [ "ENC" ],
+        "certificate" : [ "MIICnzCCAYcCBgGWtbWs/jANBgkqhkiG9w0BAQsFADATMREwDwYDVQQDDAhibHVlY29yZTAeFw0yNTA1MDkxNTQwMDRaFw0zNTA1MDkxNTQxNDRaMBMxETAPBgNVBAMMCGJsdWVjb3JlMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuOz3Ayw72YcVs+P40jbKkjh8DZI7tl8Y74X5h7igpJbdZdYV95ViD0pRdKF5YqzI3GEX+8wSXwU5xspa4dYwTTiW2i2xrodDZiw5R0UOZ5Bi0VQiW1UuVU2H3b2fqGjRInoxwUGuaVvSa4P6dhPr7XpMQjW95U1LSz16fk4oNFhTWLvamLEwHN6qJPd9H486DyE++im4Wnwf/R4UD8Rgpx5Z7criBP66lGYHpwgdIRti68ZTzf++yck8X8wuxuYJ3sLmYd6wdiCXQbZQdASnXkSicKbFGQlXOIqDldzkO5o0D9lAz5ORkF4pjVysxa1c5hjNHxojuH3KEnvfEcIUqwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQCQfsBilvrs1koKf9GbbGkwYtzt3bawhyR3w9epyjzTlomD/F0YII9zi+QUJhQwg2kevVsh4hMJ+xTBKlpsz3PpSAZL/PI3H7yNKKaLwI97ys+LzKqhlSWG3Y6um5Qi+HHwJ8x00c6DD/s1JU78PqmahgWTCPGJVHltfFVb00T/QOkNNYJMgLwREwUf/hwZ8OOLySOZ9GMbjNrbVpYiQ7TnoH3z1L72wBp3TI2G0fk61WIaB38awtyX3z4NZ4d63SP7Cvw2vG4mLlRijZ+DkDABKglxar3QTcn8SbEZ3d0Kqfa+Sl5drPvAaU5WK+FUCSDrDF9QqKu3MbWKXfjsxcsv" ],
+        "priority" : [ "100" ],
+        "algorithm" : [ "RSA-OAEP" ]
+      }
+    }, {
+      "id" : "030f737c-e88a-497a-aa48-6a0f738357d5",
+      "name" : "hmac-generated-hs512",
+      "providerId" : "hmac-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "05796679-605b-4dfd-964d-9a6d84a0b67a" ],
+        "secret" : [ "lPmxZFG49H_DfSAvTf7J7GrVme-Ei7ZOev-4wnuodx6otz7Z5OpKZmXkzlJEzM4t3zWknRRy5_ZCT6VrhI2Oizsgnngc6RDCOycKbzpUYXww6DVjb7yfTozGHQi_mfWXtHOuoCmiQUoQiS2i8UyMVH7aiJ5EZpJsjLmWwfvQnlM" ],
+        "priority" : [ "100" ],
+        "algorithm" : [ "HS512" ]
+      }
+    } ]
+  },
+  "internationalizationEnabled" : false,
+  "supportedLocales" : [ ],
+  "authenticationFlows" : [ {
+    "id" : "860d77e1-04eb-454c-9d2f-8b0de521daa5",
+    "alias" : "Account verification options",
+    "description" : "Method with which to verity the existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-email-verification",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Verify Existing Account by Re-authentication",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "74108a90-bd5b-4fbd-9c19-20db57d941ad",
+    "alias" : "Browser - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "7f540ecd-f63c-4c3e-bae5-4c7416bc98fb",
+    "alias" : "Browser - Conditional Organization",
+    "description" : "Flow to determine if the organization identity-first login is to be used",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "organization",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "24071d5e-5718-458a-9ca5-4b11da50637f",
+    "alias" : "Direct Grant - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "direct-grant-validate-otp",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "5cc95296-12c6-4321-9753-af3004d817be",
+    "alias" : "First Broker Login - Conditional Organization",
+    "description" : "Flow to determine if the authenticator that adds organization members is to be used",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "idp-add-organization-member",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "b24ffcf2-b230-4575-b1aa-618727f5ba9b",
+    "alias" : "First broker login - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "bfbc0094-09ea-44b7-b9a8-de936bd5cff6",
+    "alias" : "Handle Existing Account",
+    "description" : "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-confirm-link",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Account verification options",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "cc68c207-2c79-4268-b503-4c2a8c7fec08",
+    "alias" : "Organization",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 10,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Browser - Conditional Organization",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "e5dbd619-1afc-44bb-9cb0-758bed3023a9",
+    "alias" : "Reset - Conditional OTP",
+    "description" : "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-otp",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "cd8a8f3a-4a3c-43cf-a800-0192946573b3",
+    "alias" : "User creation or linking",
+    "description" : "Flow for the existing/non-existing user alternatives",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "create unique user config",
+      "authenticator" : "idp-create-user-if-unique",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Handle Existing Account",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "409719e8-dad7-40bb-8bd0-c03d0fe13fa9",
+    "alias" : "Verify Existing Account by Re-authentication",
+    "description" : "Reauthentication of existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-username-password-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "First broker login - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "87e23a7e-b450-4c9c-b3bf-76ef99783529",
+    "alias" : "browser",
+    "description" : "Browser based authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-cookie",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-spnego",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "identity-provider-redirector",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 25,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 26,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Organization",
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "autheticatorFlow" : true,
+      "flowAlias" : "forms",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "e38849f2-d082-4192-b14b-86b4d0fadee3",
+    "alias" : "clients",
+    "description" : "Base authentication for clients",
+    "providerId" : "client-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "client-secret",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-jwt",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-secret-jwt",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-x509",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 40,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "63b3bee0-2e4a-4833-b0bc-73abe7808c24",
+    "alias" : "direct grant",
+    "description" : "OpenID Connect Resource Owner Grant",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "direct-grant-validate-username",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "direct-grant-validate-password",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 30,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Direct Grant - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "700be787-0642-4988-af14-a6fc204256ee",
+    "alias" : "docker auth",
+    "description" : "Used by Docker clients to authenticate against the IDP",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "docker-http-basic-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "4266a780-edb6-47ec-a70d-43f15b2e2526",
+    "alias" : "first broker login",
+    "description" : "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "review profile config",
+      "authenticator" : "idp-review-profile",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "User creation or linking",
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 50,
+      "autheticatorFlow" : true,
+      "flowAlias" : "First Broker Login - Conditional Organization",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "ffd2946d-c167-4f26-9e4c-f87f72e8995d",
+    "alias" : "forms",
+    "description" : "Username, password, otp and other auth forms.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-username-password-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Browser - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "ecc1763c-5e01-495c-8f4a-1876f209c26a",
+    "alias" : "registration",
+    "description" : "Registration flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-page-form",
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : true,
+      "flowAlias" : "registration form",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "de863bee-b665-47c2-a582-6a1d4a509c1a",
+    "alias" : "registration form",
+    "description" : "Registration form",
+    "providerId" : "form-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-user-creation",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-password-action",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 50,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-recaptcha-action",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 60,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-terms-and-conditions",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 70,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "f6b37ab3-4610-4dab-b15c-78d10c62e912",
+    "alias" : "reset credentials",
+    "description" : "Reset credentials for a user if they forgot their password or something",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "reset-credentials-choose-user",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-credential-email",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-password",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 30,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 40,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Reset - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "6012639a-b696-4a3c-948d-5567d18fad68",
+    "alias" : "saml ecp",
+    "description" : "SAML ECP Profile Authentication Flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "http-basic-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  } ],
+  "authenticatorConfig" : [ {
+    "id" : "21e8ae52-f021-430b-95f0-f4b9a39d86c9",
+    "alias" : "create unique user config",
+    "config" : {
+      "require.password.update.after.registration" : "false"
+    }
+  }, {
+    "id" : "c74a3ffb-0a4a-40b9-99cb-bf9ff81ad725",
+    "alias" : "review profile config",
+    "config" : {
+      "update.profile.on.first.login" : "missing"
+    }
+  } ],
+  "requiredActions" : [ {
+    "alias" : "CONFIGURE_TOTP",
+    "name" : "Configure OTP",
+    "providerId" : "CONFIGURE_TOTP",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 10,
+    "config" : { }
+  }, {
+    "alias" : "TERMS_AND_CONDITIONS",
+    "name" : "Terms and Conditions",
+    "providerId" : "TERMS_AND_CONDITIONS",
+    "enabled" : false,
+    "defaultAction" : false,
+    "priority" : 20,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PASSWORD",
+    "name" : "Update Password",
+    "providerId" : "UPDATE_PASSWORD",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 30,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PROFILE",
+    "name" : "Update Profile",
+    "providerId" : "UPDATE_PROFILE",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 40,
+    "config" : { }
+  }, {
+    "alias" : "VERIFY_EMAIL",
+    "name" : "Verify Email",
+    "providerId" : "VERIFY_EMAIL",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 50,
+    "config" : { }
+  }, {
+    "alias" : "delete_account",
+    "name" : "Delete Account",
+    "providerId" : "delete_account",
+    "enabled" : false,
+    "defaultAction" : false,
+    "priority" : 60,
+    "config" : { }
+  }, {
+    "alias" : "webauthn-register",
+    "name" : "Webauthn Register",
+    "providerId" : "webauthn-register",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 70,
+    "config" : { }
+  }, {
+    "alias" : "webauthn-register-passwordless",
+    "name" : "Webauthn Register Passwordless",
+    "providerId" : "webauthn-register-passwordless",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 80,
+    "config" : { }
+  }, {
+    "alias" : "VERIFY_PROFILE",
+    "name" : "Verify Profile",
+    "providerId" : "VERIFY_PROFILE",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 90,
+    "config" : { }
+  }, {
+    "alias" : "delete_credential",
+    "name" : "Delete Credential",
+    "providerId" : "delete_credential",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 100,
+    "config" : { }
+  }, {
+    "alias" : "update_user_locale",
+    "name" : "Update User Locale",
+    "providerId" : "update_user_locale",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 1000,
+    "config" : { }
+  } ],
+  "browserFlow" : "browser",
+  "registrationFlow" : "registration",
+  "directGrantFlow" : "direct grant",
+  "resetCredentialsFlow" : "reset credentials",
+  "clientAuthenticationFlow" : "clients",
+  "dockerAuthenticationFlow" : "docker auth",
+  "firstBrokerLoginFlow" : "first broker login",
+  "attributes" : {
+    "cibaBackchannelTokenDeliveryMode" : "poll",
+    "cibaExpiresIn" : "120",
+    "cibaAuthRequestedUserHint" : "login_hint",
+    "oauth2DeviceCodeLifespan" : "600",
+    "clientOfflineSessionMaxLifespan" : "0",
+    "oauth2DevicePollingInterval" : "5",
+    "clientSessionIdleTimeout" : "0",
+    "parRequestUriLifespan" : "60",
+    "clientSessionMaxLifespan" : "0",
+    "clientOfflineSessionIdleTimeout" : "0",
+    "cibaInterval" : "5",
+    "realmReusableOtpCode" : "false"
+  },
+  "keycloakVersion" : "26.1.2",
+  "userManagedAccessAllowed" : false,
+  "organizationsEnabled" : false,
+  "verifiableCredentialsEnabled" : false,
+  "adminPermissionsEnabled" : false,
+  "clientProfiles" : {
+    "profiles" : [ ]
+  },
+  "clientPolicies" : {
+    "policies" : [ ]
+  }
+}

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,4 @@
+FROM nginx:1.27.4-alpine
+
+COPY bluecore.conf /etc/nginx/conf.d/default.conf
+COPY index.html /var/www/html/

--- a/nginx/bluecore.conf
+++ b/nginx/bluecore.conf
@@ -1,0 +1,27 @@
+server {
+    location / {
+        root /var/www/html;
+    }
+
+    location /api/docs {
+        proxy_pass http://bc_api:8100/docs;
+    }
+
+    location /api/openapi.json {
+        proxy_pass http://bc_api:8100/openapi.json;
+    }
+
+    location /api/ {
+        proxy_pass http://bc_api:8100/;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_protocol_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /keycloak/ {
+        proxy_pass http://keycloak:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_protocol_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/nginx/index.html
+++ b/nginx/index.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Blue Core API and Keycloak</title>
+    <link rel="stylesheet" href="https://pyscript.net/releases/2025.2.4/core.css">
+    <script type="module" src="https://pyscript.net/releases/2025.2.4/core.js"></script>
+    <style>
+      body {
+        font-family: "SF NS", BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        background-color: #f8f9fb;
+        color: #333;
+        padding: 2rem;
+        max-width: 800px;
+        margin: auto;
+      }
+
+      img {
+        display: block;
+        margin: 0 auto 1.5rem auto;
+      }
+
+      h1 {
+        text-align: center;
+        color: #00557f;
+        margin-bottom: 1rem;
+      }
+
+      ul {
+        list-style: none;
+        padding: 0;
+        margin-top: 2rem;
+      }
+
+      li {
+        background: #ffffff;
+        border: 1px solid #ddd;
+        margin-bottom: 1rem;
+        border-radius: 8px;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+        transition: box-shadow 0.2s ease;
+      }
+
+      li:hover {
+        box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+      }
+
+      a {
+        display: block;
+        padding: 1rem;
+        text-decoration: none;
+        color: #007acc;
+        font-weight: bold;
+      }
+
+      a:hover {
+        color: #00557f;
+      }
+    </style>
+  </head>
+  <body>
+    <img src="https://bluecore.info/assets/blue-core-v1.png" alt="Blue Core Logo" style="width: 150px;">
+    <h1>Blue Core API and Keycloak</h1>
+    <ul>
+      <li><a href="/api/">Blue Core API</a></li>
+      <li><a href="/api/docs">FastAPI Docs</a></li>
+      <li><a href="/keycloak/">Keycloak Account Console</a></li>
+    </ul>
+  </body>
+</html>

--- a/nginx/index.html
+++ b/nginx/index.html
@@ -61,7 +61,7 @@
   </head>
   <body>
     <img src="https://bluecore.info/assets/blue-core-v1.png" alt="Blue Core Logo" style="width: 150px;">
-    <h1>Blue Core API and Keycloak</h1>
+    <h1>Blue Core API with Keycloak</h1>
     <ul>
       <li><a href="/api/">Blue Core API</a></li>
       <li><a href="/api/docs">FastAPI Docs</a></li>

--- a/scripts/init-multi-postgres-dbs.sh
+++ b/scripts/init-multi-postgres-dbs.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+databases=("keycloak")
+
+for db in "${databases[@]}"; do
+  echo "Creating database $db"
+  psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
+    SELECT 'CREATE DATABASE $db' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '$db')\gexec
+    GRANT ALL PRIVILEGES ON DATABASE $db TO $POSTGRES_USER;
+EOSQL
+done
+

--- a/src/bluecore/app/main.py
+++ b/src/bluecore/app/main.py
@@ -36,10 +36,10 @@ app.include_router(change_documents)
 
 
 # ==============================================================================
-# Bypass Keycloak auth in local-only dev mode by setting DEVELOPER_MODE=true
+# Bypass Keycloak auth in local-only dev mode by setting BYPASS_KEYCLOAK=true
 # Sets up mocked auth and user dependencies instead of requiring real tokens
 # ------------------------------------------------------------------------------
-def enable_developer_mode(app):
+def bypass_keycloak(app):
     developer_permissions = ["create", "update"]  # update to add more permissions
 
     async def mocked_get_auth(request: Request):
@@ -51,7 +51,7 @@ def enable_developer_mode(app):
     app.dependency_overrides[get_auth] = mocked_get_auth
     app.dependency_overrides[get_user] = mocked_get_user
     print(
-        "\033[1;35m🚧 DEVELOPER_MODE is ON — Keycloak is bypassed with mock permissions\033[0m"
+        "\033[1;35m🚧 BYPASS_KEYCLOAK is ON — Keycloak is bypassed with mock permissions\033[0m"
     )
 
 
@@ -60,8 +60,8 @@ async def scope_mapper(claim_auth: list) -> list:
     return permissions
 
 
-if os.getenv("DEVELOPER_MODE") == "true":
-    enable_developer_mode(app)
+if os.getenv("BYPASS_KEYCLOAK") == "true":
+    bypass_keycloak(app)
 else:
     keycloak_config = KeycloakConfiguration(
         url=os.getenv("KEYCLOAK_URL"),


### PR DESCRIPTION
## Why was this change made?
This change introduces a Docker-based local development environment for the Blue Core API that includes Keycloak and Nginx for authentication and reverse proxy support. The goal is to allow developers to:

- Run the API and Keycloak in a unified Docker Compose environment
- Bypass Keycloak authentication for local development if desired
- See API changes in real time via FastAPI's dev mode and hot reload
- Use a reverse proxy via Nginx to route requests to the API and Keycloak through a unified interface (e.g., localhost)

## How was this change tested?
- Verified that docker compose -f compose-dev.yaml up starts the API, Keycloak, Postgres, and Nginx successfully
- Confirmed that the API is accessible at http://localhost/api/
- Confirmed FastAPI docs load at http://localhost/api/docs
- Verified Keycloak UI is reachable at http://localhost/keycloak/
- Tested bypassing Keycloak by uncommenting BYPASS_KEYCLOAK: "true" in the Compose file and confirmed mock auth enabled
- Confirmed real-time API code changes trigger hot reload in dev mode

## Which documentation and/or configurations were updated?
- Updated README.md with instructions for running the dev environment via compose-dev.yaml
- Updated section explaining how to bypass Keycloak authentication in development
- Added login instructions for accessing Keycloak’s master realm
- Created compose-dev.yaml for local development
- Added a new Dockerfile-dev
- Added  Nginx config (nginx/bluecore.conf) and index page (nginx/index.html) to route and present the local dev services
- Added a script to initialize the Postgres database with a separate keycloak DB



