### PR TITLE
Removes Secret to use Public Keyclock Client

### DIFF
--- a/src/bluecore/app/main.py
+++ b/src/bluecore/app/main.py
@@ -70,7 +70,6 @@ else:
         url=os.getenv("KEYCLOAK_URL"),
         realm=os.getenv("KEYCLOAK_REALM"),
         client_id=os.getenv("API_KEYCLOAK_CLIENT_ID"),
-        client_secret=os.getenv("API_KEYCLOAK_CLIENT_SECRET"),
         authorization_method=AuthorizationMethod.CLAIM,
         authorization_claim="realm_access",
     )


### PR DESCRIPTION
## Why was this change made?
The API should use a public [Keycloak client ](https://www.keycloak.org/securing-apps/javascript-adapter#_keycloak_server_configuration) to enable web client editors like Sinopia and Marva to use Keycloak without storing the secret in the web browser environment.


## How was this change tested?
Unit tests and testing API through Jupyter Notebook.


## Which documentation and/or configurations were updated?
n/a



