### PR TITLE
Distinguish internal and external Airflow URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ Next you will want to clone bluecore_api repository and create a `.env` file tha
 # service uris
 DATABASE_URL="postgresql://airflow:airflow@localhost/bluecore"
 BLUECORE_URL="http://localhost:3000/"
-AIRFLOW_URL="http://localhost:8080/"
-KEYCLOAK_URL="http://localhost:8081/keycloak/"
+AIRFLOW_INTERNAL_URL="http://localhost:8080"
+KEYCLOAK_EXTERNAL_URL="http://localhost:8081/keycloak/"
+KEYCLOAK_INTERNAL_URL="http://localhost:8081/keycloak/"
 
 # keycloak config so blucore_api users can authenticate
 API_KEYCLOAK_CLIENT_ID="bluecore_api"

--- a/src/bluecore_api/app/main.py
+++ b/src/bluecore_api/app/main.py
@@ -48,7 +48,7 @@ if os.getenv("DEVELOPER_MODE") == "true":
     application = base_app
 else:
     keycloak_config = KeycloakConfiguration(
-        url=os.getenv("KEYCLOAK_URL"),
+        url=os.getenv("KEYCLOAK_INTERNAL_URL"),
         realm="bluecore",
         client_id=os.getenv("API_KEYCLOAK_CLIENT_ID"),
         authorization_method=AuthorizationMethod.CLAIM,

--- a/src/bluecore_api/workflow.py
+++ b/src/bluecore_api/workflow.py
@@ -6,9 +6,7 @@ import httpx
 
 AIRFLOW_USER = os.environ.get("AIRFLOW_WWW_USER_USERNAME")
 AIRFLOW_PASSWORD = os.environ.get("AIRFLOW_WWW_USER_PASSWORD")
-AIRFLOW_URL = os.environ.get(
-    "AIRFLOW_URL", "http://airflow-webserver:8080/workflows"
-).rstrip("/")
+AIRFLOW_INTERNAL_URL = os.environ.get("AIRFLOW_INTERNAL_URL").rstrip("/")
 
 
 async def create_batch_from_uri(uri: str) -> str:
@@ -19,7 +17,7 @@ async def create_batch_from_uri(uri: str) -> str:
 
     token = await get_token()
 
-    url = f"{AIRFLOW_URL}/api/v2/dags/resource_loader/dagRuns"
+    url = f"{AIRFLOW_INTERNAL_URL}/api/v2/dags/resource_loader/dagRuns"
     now = datetime.datetime.now(tz=datetime.UTC).isoformat()
 
     async with httpx.AsyncClient() as client:
@@ -52,7 +50,7 @@ async def get_token() -> str:
     # See: https://github.com/apache/airflow/issues/51362
 
     resp = httpx.post(
-        f"{AIRFLOW_URL}/auth/token",
+        f"{AIRFLOW_INTERNAL_URL}/auth/token",
         json={"username": AIRFLOW_USER, "password": AIRFLOW_PASSWORD},
     )
     resp.raise_for_status()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,8 +26,8 @@ if os.getenv("DATABASE_URL") is None:
         "postgresql://bluecore_admin:bluecore_admin@localhost/bluecore"
     )
 
-os.environ["AIRFLOW_URL"] = "http://airflow:8080"
-os.environ["KEYCLOAK_URL"] = "http://localhost:8080/auth"
+os.environ["AIRFLOW_INTERNAL_URL"] = "http://airflow:8080"
+os.environ["KEYCLOAK_INTERNAL_URL"] = "http://localhost:8080/auth"
 os.environ["KEYCLOAK_REALM"] = "bluecore"
 os.environ["API_KEYCLOAK_CLIENT_ID"] = "bluecore"
 os.environ["API_KEYCLOAK_CLIENT_SECRET"] = "abcded235"


### PR DESCRIPTION
It's important that the bluecore_api communicate with bluecore-workflows using AIRFLOW_INTERNAL_URL to distinguish it from AIRFLOW_EXTERNAL_URL which is needed in Terraform to tell Airflow the public proxied URL.

For clarity it's also better to rely on KEYCLOAK_INTERNAL_URL and KEYCLOAK_EXTERNAL_URL that are used in bluecore-workflows instead of overloading KEYCLOAK_URL.
