### PR TITLE
Add bluecore load-url command

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ uv run dotenv run fastapi dev src/bluecore_api/app/main.py --port 3000
 If you want to try loading some data you can use the `bluecore` utility:
 
 ```shell
-uv run bluecore load sample/batch.jsonld 
+uv run bluecore load-url https://raw.githubusercontent.com/blue-core-lod/bluecore_api/refs/heads/main/sample/batch.jsonld
 ```
 
-This will load a batch of data to the bluecore_api API, and tell [Blue Core Workflows] to load it.
+This will tell the Blue Core API to load the data at that URL into the database.
 
 ## HTTP Requests
 

--- a/src/bluecore_api/cli.py
+++ b/src/bluecore_api/cli.py
@@ -27,7 +27,7 @@ def token():
 
 
 @app.command()
-def load(
+def load_file(
     file: Annotated[
         Path, Argument(exists=True, dir_okay=False, readable=True, resolve_path=True)
     ],
@@ -41,6 +41,27 @@ def load(
             f"{state['api_url']}/batches/upload/",
             headers={"Authorization": f"Bearer {token}"},
             files={"file": file.open("rb")},
+        )
+
+        resp.raise_for_status()
+        printr(resp.json())
+
+    except httpx.HTTPError as e:
+        printr(f"[red]{e}[/red]")
+        raise Exit(1)
+
+
+@app.command()
+def load_url(url: Annotated[str, Argument()]):
+    """
+    Upload a Bibframe JSON-LD document URL as a batch import.
+    """
+    try:
+        token = _get_token()
+        resp = httpx.post(
+            f"{state['api_url']}/batches/",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"uri": url},
         )
 
         resp.raise_for_status()


### PR DESCRIPTION
The load-url command will load JSON-LD at a given URL into the database using the Blue Core API.

```shell
$ uv run bluecore load-url https://raw.githubusercontent.com/blue-core-lod/bluecore_api/refs/heads/main/sample/batch.jsonld
```
The old `load` command is now `load-file`.
