### PR TITLE
Fix/fastapi keycloak middleware version1.3.0 issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ BLUECORE_URL="http://localhost:3000/"
 AIRFLOW_INTERNAL_URL="http://localhost:8080"
 KEYCLOAK_EXTERNAL_URL="http://localhost:8081/keycloak/"
 KEYCLOAK_INTERNAL_URL="http://localhost:8081/keycloak/"
+USE_KEYCLOAK_INTROSPECTION=true # Set to false in production (defaults to true for dev and testing)
 
 # keycloak config so blucore_api users can authenticate
 API_KEYCLOAK_CLIENT_ID="bluecore_api"

--- a/src/bluecore_api/app/main.py
+++ b/src/bluecore_api/app/main.py
@@ -48,7 +48,8 @@ if os.getenv("DEVELOPER_MODE") == "true":
     application = base_app
 else:
     keycloak_config = KeycloakConfiguration(
-        use_introspection_endpoint=os.getenv("USE_KEYCLOAK_INTROSPECTION", "true") == "true",
+        use_introspection_endpoint=os.getenv("USE_KEYCLOAK_INTROSPECTION", "true")
+        == "true",
         url=os.getenv("KEYCLOAK_INTERNAL_URL"),
         realm="bluecore",
         client_id=os.getenv("API_KEYCLOAK_CLIENT_ID"),

--- a/src/bluecore_api/app/main.py
+++ b/src/bluecore_api/app/main.py
@@ -48,6 +48,7 @@ if os.getenv("DEVELOPER_MODE") == "true":
     application = base_app
 else:
     keycloak_config = KeycloakConfiguration(
+        use_introspection_endpoint=os.getenv("USE_KEYCLOAK_INTROSPECTION", "true") == "true",
         url=os.getenv("KEYCLOAK_INTERNAL_URL"),
         realm="bluecore",
         client_id=os.getenv("API_KEYCLOAK_CLIENT_ID"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,8 +34,6 @@ os.environ["API_KEYCLOAK_CLIENT_SECRET"] = "abcded235"
 
 os.environ["ACTIVITY_STREAMS_PAGE_LENGTH"] = "2"
 os.environ["ACTIVITY_STREAMS_HOST"] = "http://127.0.0.1:3000"
-os.environ["DEVELOPER_MODE"] = "true"
-
 
 @pytest.fixture(scope="session")
 def pmr_postgres_config():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,7 @@ os.environ["API_KEYCLOAK_CLIENT_SECRET"] = "abcded235"
 os.environ["ACTIVITY_STREAMS_PAGE_LENGTH"] = "2"
 os.environ["ACTIVITY_STREAMS_HOST"] = "http://127.0.0.1:3000"
 
+
 @pytest.fixture(scope="session")
 def pmr_postgres_config():
     return PostgresConfig(image="postgres:16-alpine")


### PR DESCRIPTION
## Why was this change made?
to allow api to work with ` fastapi-keycloak-middleware` version `1.3.0`


## How was this change tested?
locally with running uv and pystest


## Which documentation and/or configurations were updated?
added `USE_KEYCLOAK_INTROSPECTION` environment variable and config option in keycloak to allow to work properly.



