### PR TITLE
W48/ensure jsonld is persisted

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
   "pgvector",
   "psycopg2-binary>=2.9.10",
   "rdflib>=7.1.3",
-  "bluecore-models>=0.6.0",
+  "bluecore-models>=0.7.0",
   "python-multipart>=0.0.20",
   "fastapi-keycloak-middleware>=1.2.0",
   "typer>=0.15.4",

--- a/src/bluecore_api/app/routes/instances.py
+++ b/src/bluecore_api/app/routes/instances.py
@@ -1,4 +1,5 @@
 import os
+import rdflib
 
 from datetime import datetime, UTC
 
@@ -8,7 +9,7 @@ from fastapi_keycloak_middleware import CheckPermissions
 
 from sqlalchemy.orm import Session
 
-from bluecore_models.utils.graph import handle_external_subject
+from bluecore_models.utils.graph import frame_jsonld, handle_external_subject
 from bluecore_models.models import Instance
 
 from bluecore_api.database import get_db
@@ -75,7 +76,8 @@ async def update_instance(
 
     # Update fields if they are provided
     if instance.data is not None:
-        db_instance.data = instance.data
+        graph = rdflib.Graph().parse(data=instance.data, format="json-ld")
+        db_instance.data = frame_jsonld(db_instance.uri, graph)
     if instance.work_id is not None:
         db_instance.work_id = instance.work_id
 

--- a/src/bluecore_api/app/routes/works.py
+++ b/src/bluecore_api/app/routes/works.py
@@ -1,15 +1,15 @@
 import os
+import rdflib
 
 from datetime import datetime, UTC
 
 from fastapi import APIRouter, Depends, HTTPException
-
 from fastapi_keycloak_middleware import CheckPermissions
 
 from sqlalchemy.orm import Session
 
 from bluecore_models.models import Work
-from bluecore_models.utils.graph import handle_external_subject
+from bluecore_models.utils.graph import frame_jsonld, handle_external_subject
 
 from bluecore_api.database import get_db
 from bluecore_api.schemas.schemas import (
@@ -69,7 +69,8 @@ async def update_work(
 
     # Update data if it is provided
     if work.data is not None:
-        db_work.data = work.data
+        graph = rdflib.Graph().parse(data=work.data, format="json-ld")
+        db_work.data = frame_jsonld(db_work.uri, graph)
 
     db.commit()
     db.refresh(db_work)

--- a/src/bluecore_api/schemas/schemas.py
+++ b/src/bluecore_api/schemas/schemas.py
@@ -3,6 +3,8 @@ from typing import Optional
 from pydantic import BaseModel
 from datetime import datetime
 from bluecore_api.constants import BluecoreType
+from typing import Any, Dict
+from uuid import UUID
 
 
 class ErrorResponse(BaseModel):
@@ -14,8 +16,9 @@ class ErrorResponse(BaseModel):
 class ResourceBaseSchema(BaseModel):
     id: Optional[int]
     type: str
-    data: str
+    data: Dict[str, Any]
     uri: Optional[str]
+    uuid: Optional[UUID]
     created_at: Optional[datetime]
     updated_at: Optional[datetime]
 

--- a/tests/api/test_instance.py
+++ b/tests/api/test_instance.py
@@ -53,16 +53,16 @@ def test_create_instance(client):
         "https://bluecore.info/instances/75d831b9-e0d6-40f0-abb3-e9130622eb8a"
     )
 
-    assert str(new_work_uri).startswith(
-        "https://bcld.info/instances"
-    ), "Minted URI uses default base url https://bcld.info/"
+    assert str(new_work_uri).startswith("https://bcld.info/instances"), (
+        "Minted URI uses default base url https://bcld.info/"
+    )
 
     # Assert timestamps exist and are identical
     assert "created_at" in data
     assert "updated_at" in data
-    assert (
-        data["created_at"] == data["updated_at"]
-    ), "created_at and updated_at should match on creation"
+    assert data["created_at"] == data["updated_at"], (
+        "created_at and updated_at should match on creation"
+    )
 
 
 def test_update_instance(client, db_session):
@@ -115,9 +115,9 @@ def test_update_instance(client, db_session):
     # Assert timestamps exist and are now different
     assert "created_at" in payload
     assert "updated_at" in payload
-    assert (
-        payload["created_at"] != payload["updated_at"]
-    ), "created_at and updated_at should not match on update"
+    assert payload["created_at"] != payload["updated_at"], (
+        "created_at and updated_at should not match on update"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/api/test_instance.py
+++ b/tests/api/test_instance.py
@@ -4,24 +4,28 @@ import pytest
 import rdflib
 
 from bluecore_models.models import Instance
-from bluecore_models.utils.graph import init_graph, BF
+from bluecore_models.utils.graph import frame_jsonld, init_graph, BF
 
 
 def test_get_instance(client, db_session):
+    test_instance_uuid = "75d831b9-e0d6-40f0-abb3-e9130622eb8a"
+    test_instance_bluecore_uri = f"https://bcld.info/instances/{test_instance_uuid}"
+    graph = rdflib.Graph().parse(
+        data=pathlib.Path("tests/blue-core-work.jsonld").read_text(), format="json-ld"
+    )
+    data = frame_jsonld(test_instance_bluecore_uri, graph)
     db_session.add(
         Instance(
             id=2,
-            uuid="75d831b9-e0d6-40f0-abb3-e9130622eb8a",
-            uri="https://bcld.info/instances/75d831b9-e0d6-40f0-abb3-e9130622eb8a",
-            data=pathlib.Path("tests/blue-core-instance.jsonld").read_text(),
+            uuid=test_instance_uuid,
+            uri=test_instance_bluecore_uri,
+            data=data,
         )
     )
 
-    response = client.get("/instances/75d831b9-e0d6-40f0-abb3-e9130622eb8a")
+    response = client.get(f"/instances/{test_instance_uuid}")
     assert response.status_code == 200
-    assert response.json()["uri"].startswith(
-        "https://bcld.info/instances/75d831b9-e0d6-40f0-abb3-e9130622eb8a"
-    )
+    assert response.json()["uri"].startswith(test_instance_bluecore_uri)
 
 
 def test_create_instance(client):
@@ -49,16 +53,16 @@ def test_create_instance(client):
         "https://bluecore.info/instances/75d831b9-e0d6-40f0-abb3-e9130622eb8a"
     )
 
-    assert str(new_work_uri).startswith("https://bcld.info/instances"), (
-        "Minted URI uses default base url https://bcld.info/"
-    )
+    assert str(new_work_uri).startswith(
+        "https://bcld.info/instances"
+    ), "Minted URI uses default base url https://bcld.info/"
 
     # Assert timestamps exist and are identical
     assert "created_at" in data
     assert "updated_at" in data
-    assert data["created_at"] == data["updated_at"], (
-        "created_at and updated_at should match on creation"
-    )
+    assert (
+        data["created_at"] == data["updated_at"]
+    ), "created_at and updated_at should match on creation"
 
 
 def test_update_instance(client, db_session):
@@ -111,6 +115,10 @@ def test_update_instance(client, db_session):
     # Assert timestamps exist and are now different
     assert "created_at" in payload
     assert "updated_at" in payload
-    assert payload["created_at"] != payload["updated_at"], (
-        "created_at and updated_at should not match on update"
-    )
+    assert (
+        payload["created_at"] != payload["updated_at"]
+    ), "created_at and updated_at should not match on update"
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/tests/api/test_work.py
+++ b/tests/api/test_work.py
@@ -59,9 +59,9 @@ def test_create_work(client, mocker):
     # Assert timestamps exist and are identical
     assert "created_at" in data
     assert "updated_at" in data
-    assert (
-        data["created_at"] == data["updated_at"]
-    ), "created_at and updated_at should match on creation"
+    assert data["created_at"] == data["updated_at"], (
+        "created_at and updated_at should match on creation"
+    )
 
 
 def test_update_work(client, db_session):
@@ -112,9 +112,9 @@ def test_update_work(client, db_session):
     # Assert timestamps exist and are now different
     assert "created_at" in data
     assert "updated_at" in data
-    assert (
-        data["created_at"] != data["updated_at"]
-    ), "created_at and updated_at should not match on update"
+    assert data["created_at"] != data["updated_at"], (
+        "created_at and updated_at should not match on update"
+    )
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -86,7 +86,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bluecore-models", specifier = ">=0.6.0" },
+    { name = "bluecore-models", specifier = ">=0.7.0" },
     { name = "fastapi", extras = ["standard"] },
     { name = "fastapi-keycloak-middleware", specifier = ">=1.2.0" },
     { name = "pgvector" },
@@ -110,7 +110,7 @@ dev = [
 
 [[package]]
 name = "bluecore-models"
-version = "0.6.2"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "alembic" },
@@ -118,9 +118,9 @@ dependencies = [
     { name = "pyld" },
     { name = "rdflib" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d0/49/cdbf2e499ff7d6e0e14e1d1c6741be79186edcc7e564bbda3708783020d7/bluecore_models-0.6.2.tar.gz", hash = "sha256:6f8ea0bcf9cf6fbd0dae4be808080ee3abfe04f2e01bb1d786587ce9551d2a86", size = 40976 }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/68/fff60fa8df0e85fc6703954ced6ef0b3c75b0c4b583d4ddb3953283926a6/bluecore_models-0.7.0.tar.gz", hash = "sha256:4eabae6e334d3b39a6fd9c3fd37fbdee50d783843670f157095df20c409c14d6", size = 40948 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/d9/90e226ebb5e79d96371ba8bf729e55dfd225e4169dfec769c69d6e0133b7/bluecore_models-0.6.2-py3-none-any.whl", hash = "sha256:60526c78916842010a2769379090035de2dfb1f03c34ade26c148df2c6330f6f", size = 11286 },
+    { url = "https://files.pythonhosted.org/packages/55/28/fe40c9f774bd62b4760f18a61510e7322d534fff1b843494051950566c54/bluecore_models-0.7.0-py3-none-any.whl", hash = "sha256:53fb69cc47394856e74a65d3a3174fd5bb79f1eca26c3571c195c8c0826eb056", size = 11271 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why was this change made?
The data for works/instances are Dict and APi needs to be updated as it treats as str.


## How was this change tested?
All unit tests pass


## Which documentation and/or configurations were updated?
N/A



