### PR TITLE
Add dummy search implementation

### DIFF
--- a/src/bluecore_api/app/main.py
+++ b/src/bluecore_api/app/main.py
@@ -4,7 +4,7 @@ import sys
 from pathlib import Path
 from uuid import uuid4
 
-from fastapi import Depends, FastAPI, HTTPException, File, UploadFile, Request
+from fastapi import Depends, FastAPI, HTTPException, File, UploadFile
 from fastapi_keycloak_middleware import (
     AuthorizationMethod,
     CheckPermissions,
@@ -23,6 +23,7 @@ from bluecore_api import workflow
 from bluecore_api.change_documents.routes import change_documents
 from bluecore_api.app.routes.instances import endpoints as instance_routes
 from bluecore_api.app.routes.other_resources import endpoints as resource_routes
+from bluecore_api.app.routes.search import endpoints as search_routes
 from bluecore_api.app.routes.works import endpoints as work_routes
 from bluecore_api.schemas.schemas import BatchCreateSchema, BatchSchema
 
@@ -32,6 +33,7 @@ base_app = FastAPI(root_path="/api")
 base_app.include_router(change_documents)
 base_app.include_router(instance_routes)
 base_app.include_router(resource_routes)
+base_app.include_router(search_routes)
 base_app.include_router(work_routes)
 
 BLUECORE_URL = os.environ.get("BLUECORE_URL", "https://bcld.info/")

--- a/src/bluecore_api/app/routes/search.py
+++ b/src/bluecore_api/app/routes/search.py
@@ -1,0 +1,36 @@
+from bluecore_api.database import get_db
+from bluecore_api.schemas.schemas import (
+    ResourceBaseSchema,
+)
+from bluecore_models.models import Instance, ResourceBase, Work
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+from typing import List
+
+endpoints = APIRouter()
+
+
+@endpoints.get(
+    "/search/",
+    response_model=List[ResourceBaseSchema],
+)
+async def search(db: Session = Depends(get_db), type: str = "all", q: str = ""):
+    match type:
+        case "all":
+            stmt = (
+                select(ResourceBase)
+                .where(ResourceBase.type != "other_resources")
+                .limit(10)
+            )
+        case "works":
+            stmt = select(Work).limit(10)
+        case "instances":
+            stmt = select(Instance).limit(10)
+        case _:
+            raise HTTPException(status_code=400, detail="Invalid type specified")
+    results: List[ResourceBase] = []
+    for entry in db.execute(stmt).scalars().all():
+        results.append(entry)
+
+    return results

--- a/src/bluecore_api/middleware/keycloak_auth.py
+++ b/src/bluecore_api/middleware/keycloak_auth.py
@@ -49,7 +49,7 @@ class BypassKeycloakForGet:
         "/api/instances/",
         "/api/works/",
         "/change_documents/",
-        "/search/",
+        "/search",
     }
 
     def __init__(self, app, keycloak_middleware):

--- a/src/bluecore_api/middleware/keycloak_auth.py
+++ b/src/bluecore_api/middleware/keycloak_auth.py
@@ -43,7 +43,14 @@ class BypassKeycloakForGet:
     }
 
     """Add GET path prefixes (e.g., /instances/, /works/)"""
-    PREFIX_PATHS = {"/instances/", "/works/", "/api/instances/", "/api/works/"}
+    PREFIX_PATHS = {
+        "/instances/",
+        "/works/",
+        "/api/instances/",
+        "/api/works/",
+        "/change_documents/",
+        "/search/",
+    }
 
     def __init__(self, app, keycloak_middleware):
         self.inner_app = app


### PR DESCRIPTION
## Why was this change made?
Add dummy search implementation
/search lists 10 works/instances from DB
type parameter can be specified to limit search result to works or instances, defaults to returning both
e.g /search?type=works, /search/?type=instances

## How was this change tested?
N/A


## Which documentation and/or configurations were updated?
N/A



