### PR TITLE
Adds CORS middleware to support JS clients

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-api"
-version = "0.2.7"
+version = "0.3.0"
 description = "Blue Core API for managing BIBFRAME RDF data and workflows"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/bluecore_api/app/main.py
+++ b/src/bluecore_api/app/main.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from uuid import uuid4
 
 from fastapi import Depends, FastAPI, HTTPException, File, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+
 from fastapi_keycloak_middleware import (
     AuthorizationMethod,
     CheckPermissions,
@@ -12,6 +14,7 @@ from fastapi_keycloak_middleware import (
     KeycloakMiddleware,
 )
 from fastapi_pagination import add_pagination
+
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/../../")
 
@@ -73,6 +76,12 @@ else:
         app=base_app, keycloak_middleware=keycloak_middleware
     )
     application = CompatibleFastAPI(app=middleware_wrapped_app)
+    base_app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],  # Allows for any local client to connect
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
 
 
 @base_app.get("/")

--- a/uv.lock
+++ b/uv.lock
@@ -59,7 +59,7 @@ wheels = [
 
 [[package]]
 name = "bluecore-api"
-version = "0.2.7"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "bluecore-models" },


### PR DESCRIPTION
## Why was this change made?
Fixes #123 

Following the [Sinopia API approach](https://github.com/LD4P/sinopia_api/blob/de7a32f5fdb270ca1007070aa9ef6cc763412ee7/src/app.js#L33-L34), using a `*` wildcard to allow any Javascript client to connect instead of manually specifying different localhost/port combinations. We may want to revisit this in the MVP phase when we know what clients like Sinopia/Graph Toolbox/Marva require to run locally.

## How was this change tested?
Unit tests


## Which documentation and/or configurations were updated?
n/a



