### PR TITLE
version-bump: updated model, uv-sync called

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
   "pgvector",
   "psycopg2-binary>=2.9.10",
   "rdflib>=7.1.3",
-  "bluecore-models>=0.8.2",
+  "bluecore-models>=0.9.2",
   "python-multipart>=0.0.20",
   "fastapi-keycloak-middleware>=1.2.0",
   "typer>=0.15.4",

--- a/uv.lock
+++ b/uv.lock
@@ -87,7 +87,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bluecore-models", specifier = ">=0.8.2" },
+    { name = "bluecore-models", specifier = ">=0.9.2" },
     { name = "fastapi", extras = ["standard"] },
     { name = "fastapi-keycloak-middleware", specifier = ">=1.2.0" },
     { name = "fastapi-pagination" },
@@ -112,7 +112,7 @@ dev = [
 
 [[package]]
 name = "bluecore-models"
-version = "0.8.2"
+version = "0.9.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "alembic" },
@@ -121,9 +121,9 @@ dependencies = [
     { name = "pymilvus", extra = ["model"] },
     { name = "rdflib" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b6/2c/56ae64c3c1c2e79e11e742f633ef81b8524d0c8cc99029b4947fc84fda12/bluecore_models-0.8.2.tar.gz", hash = "sha256:d15d06f81de56327eafa2696789de8220ef581fe361e0da914e2d6c1c865cdc3", size = 74049 }
+sdist = { url = "https://files.pythonhosted.org/packages/17/2d/102e6552a6b0a1025b14110b7ff2d8e3ab5aac03ed739891597e357f7dce/bluecore_models-0.9.2.tar.gz", hash = "sha256:4653258a04f608e8107f14294389c98a2058b29adf524bfd110641d4369f1179", size = 79122 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/1d/f0de4ed8112085bb5d5889b37afa3e8cb0dfdc888d38003fc670ff6eb370/bluecore_models-0.8.2-py3-none-any.whl", hash = "sha256:1e7bd0242dd4821a14a0b6290d4828c79b569d76951da8a07758f319a8020359", size = 12852 },
+    { url = "https://files.pythonhosted.org/packages/64/97/72fb0a72160600c71be2cf0d17fadd25c0f49025e8aea7466c61ede22d73/bluecore_models-0.9.2-py3-none-any.whl", hash = "sha256:7362bd79028d553d648866155a108449d14ba226815dba40ff724b6d669d7277", size = 12908 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why was this change made?
to use the latest models release (v0.9.2)

## How was this change tested?
pytest


## Which documentation and/or configurations were updated?
n/a


