### PR TITLE
Fix incorrect activity stream page url for prod

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-api"
-version = "0.5.0"
+version = "0.5.1"
 description = "Blue Core API for managing BIBFRAME RDF data and workflows"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/bluecore_api/change_documents/change_set.py
+++ b/src/bluecore_api/change_documents/change_set.py
@@ -81,12 +81,20 @@ class EntityChangeActivity(EntityChangeActivitiesSchema):
 
 class ChangeSet(Counter, ChangeSetSchema):
     def __init__(
-        self, db: Session, bc_type: BluecoreType, id: int, host: str, page_length: int
+        self,
+        db: Session,
+        bc_type: BluecoreType,
+        id: int,
+        change_documents_url: str,
+        page_length: int,
     ):
         total = self.total_items(db=db, bc_type=bc_type)
         total_pages = math.ceil(total / page_length)
         prev_next = self.determine_prev_next(
-            id=id, total_pages=total_pages, bc_type=bc_type, host=host
+            id=id,
+            total_pages=total_pages,
+            bc_type=bc_type,
+            change_documents_url=change_documents_url,
         )
 
         stmt = (
@@ -103,8 +111,8 @@ class ChangeSet(Counter, ChangeSetSchema):
             ordered_items.append(EntityChangeActivity(version=version))
 
         super().__init__(
-            id=f"{host}/change_documents/{bc_type}/page/{id}",
-            partOf=f"{host}/change_documents/{bc_type}/feed",
+            id=f"{change_documents_url}/{bc_type}/page/{id}",
+            partOf=f"{change_documents_url}/{bc_type}/feed",
             prev=prev_next["prev"],
             next=prev_next["next"],
             orderedItems=ordered_items,
@@ -116,7 +124,7 @@ class ChangeSet(Counter, ChangeSetSchema):
         id: int,
         total_pages: int,
         bc_type: BluecoreType,
-        host: str,
+        change_documents_url: str,
     ) -> Dict[str, Union[str, None]]:
         """
         Out of bounds conditions are not handled here.
@@ -126,12 +134,12 @@ class ChangeSet(Counter, ChangeSetSchema):
         if prev_id < 1:
             prev = None
         else:
-            prev = f"{host}/change_documents/{bc_type}/page/{prev_id}"
+            prev = f"{change_documents_url}/{bc_type}/page/{prev_id}"
 
         next_id = id + 1
         if next_id > total_pages:
             next = None
         else:
-            next = f"{host}/change_documents/{bc_type}/page/{next_id}"
+            next = f"{change_documents_url}/{bc_type}/page/{next_id}"
 
         return {"prev": prev, "next": next}

--- a/src/bluecore_api/change_documents/entry_point.py
+++ b/src/bluecore_api/change_documents/entry_point.py
@@ -10,19 +10,25 @@ import math
 
 
 class EntryPoint(Counter, EntryPointSchema):
-    def __init__(self, db: Session, bc_type: BluecoreType, host: str, page_length: int):
+    def __init__(
+        self,
+        db: Session,
+        bc_type: BluecoreType,
+        change_documents_url: str,
+        page_length: int,
+    ):
         total = self.total_items(db=db, bc_type=bc_type)
         last_page: int = math.ceil(total / page_length)
         super().__init__(
             summary="Bluecore Activity Streams Entry Point",
-            id=f"{host}/change_documents/{bc_type}/feed",
+            id=f"{change_documents_url}/{bc_type}/feed",
             totalItems=total,
             first={
-                "id": f"{host}/change_documents/{bc_type}/page/1",
+                "id": f"{change_documents_url}/{bc_type}/page/1",
                 "type": "OrderedCollectionPage",
             },
             last={
-                "id": f"{host}/change_documents/{bc_type}/page/{last_page}",
+                "id": f"{change_documents_url}/{bc_type}/page/{last_page}",
                 "type": "OrderedCollectionPage",
             },
         )

--- a/src/bluecore_api/change_documents/routes.py
+++ b/src/bluecore_api/change_documents/routes.py
@@ -13,7 +13,10 @@ import os
 page_length: int = int(
     os.getenv("ACTIVITY_STREAMS_PAGE_LENGTH", DEFAULT_ACTIVITY_STREAMS_PAGE_LENGTH)
 )
-host: str = os.getenv("BLUECORE_URL", "http://127.0.0.1:3000").rstrip("/")
+
+change_documents_url: str = os.getenv(
+    "CHANGE_DOCUMENTS_URL", "https://bcld.info/api/change_documents"
+).rstrip("/")
 
 change_documents = APIRouter()
 
@@ -29,7 +32,7 @@ async def instances_entry_point(
     return EntryPoint(
         db=db,
         bc_type=BluecoreType.INSTANCES,
-        host=host,
+        change_documents_url=change_documents_url,
         page_length=page_length,
     )
 
@@ -47,7 +50,7 @@ async def instances_change_set(
         db=db,
         bc_type=BluecoreType.INSTANCES,
         id=id,
-        host=host,
+        change_documents_url=change_documents_url,
         page_length=page_length,
     )
 
@@ -63,7 +66,7 @@ async def works_entry_point(
     return EntryPoint(
         db=db,
         bc_type=BluecoreType.WORKS,
-        host=host,
+        change_documents_url=change_documents_url,
         page_length=page_length,
     )
 
@@ -81,6 +84,6 @@ async def works_change_set(
         db=db,
         bc_type=BluecoreType.WORKS,
         id=id,
-        host=host,
+        change_documents_url=change_documents_url,
         page_length=page_length,
     )

--- a/tests/change_documents/test_change_set.py
+++ b/tests/change_documents/test_change_set.py
@@ -14,7 +14,7 @@ import pytest
 
 
 TEST_PAGE_LENGTH = 2
-HOST = "http://127.0.0.1:3000"
+CHANGE_DOCUMENTS_URL = "https://bcld.info/api/change_documents"
 
 
 def add_works(db: Session, start_index: int) -> None:
@@ -84,18 +84,16 @@ def test_work_change_set_add(client: TestClient, db_session: Session) -> None:
         db=db_session,
         bc_type=BluecoreType.WORKS,
         id=page_id,
-        host=HOST,
+        change_documents_url=CHANGE_DOCUMENTS_URL,
         page_length=TEST_PAGE_LENGTH,
     )
     assert change_set.totalItems == 2
     assert change_set.prev is None
-    assert (
-        change_set.next
-        == f"http://127.0.0.1:3000/change_documents/works/page/{page_id + 1}"
-    )
+    assert change_set.next == f"{CHANGE_DOCUMENTS_URL}/works/page/{page_id + 1}"
     assert change_set.orderedItems[0].type == "Create"
     assert change_set.orderedItems[0].object.type == f"bf:{BibframeType.WORK}"
 
+    # The client should use the default value for CHANGE_DOCUMENTS_URL
     response = client.get(f"/change_documents/works/page/{page_id}")
     assert response.status_code == 200
     as_schema = ChangeSetSchema.model_validate(change_set)
@@ -113,14 +111,11 @@ def test_work_entry_point_update(client: TestClient, db_session: Session) -> Non
         db=db_session,
         bc_type=BluecoreType.WORKS,
         id=page_id,
-        host=HOST,
+        change_documents_url=CHANGE_DOCUMENTS_URL,
         page_length=TEST_PAGE_LENGTH,
     )
     assert change_set.totalItems == 2
-    assert (
-        change_set.prev
-        == f"http://127.0.0.1:3000/change_documents/works/page/{page_id - 1}"
-    )
+    assert change_set.prev == f"{CHANGE_DOCUMENTS_URL}/works/page/{page_id - 1}"
     assert change_set.next is None
     assert change_set.orderedItems[0].type == "Update"
     assert change_set.orderedItems[0].object.type == f"bf:{BibframeType.WORK}"
@@ -137,14 +132,11 @@ def test_instance_entry_point_add(client: TestClient, db_session: Session) -> No
         db=db_session,
         bc_type=BluecoreType.INSTANCES,
         id=page_id,
-        host=HOST,
+        change_documents_url=CHANGE_DOCUMENTS_URL,
         page_length=TEST_PAGE_LENGTH,
     )
     assert change_set.totalItems == 2
-    assert (
-        change_set.prev
-        == f"http://127.0.0.1:3000/change_documents/instances/page/{page_id - 1}"
-    )
+    assert change_set.prev == f"{CHANGE_DOCUMENTS_URL}/instances/page/{page_id - 1}"
     assert change_set.next is None
     assert change_set.orderedItems[0].type == "Create"
     assert change_set.orderedItems[0].object.type == f"bf:{BibframeType.INSTANCE}"
@@ -162,7 +154,7 @@ def test_instance_entry_point_update(client: TestClient, db_session: Session) ->
         db=db_session,
         bc_type=BluecoreType.INSTANCES,
         id=1,
-        host=HOST,
+        change_documents_url=CHANGE_DOCUMENTS_URL,
         page_length=TEST_PAGE_LENGTH,
     )
     assert change_set.orderedItems[0].type == "Create"
@@ -173,18 +165,12 @@ def test_instance_entry_point_update(client: TestClient, db_session: Session) ->
         db=db_session,
         bc_type=BluecoreType.INSTANCES,
         id=page_id,
-        host=HOST,
+        change_documents_url=CHANGE_DOCUMENTS_URL,
         page_length=TEST_PAGE_LENGTH,
     )
     assert change_set.totalItems == 2
-    assert (
-        change_set.prev
-        == f"http://127.0.0.1:3000/change_documents/instances/page/{page_id - 1}"
-    )
-    assert (
-        change_set.next
-        == f"http://127.0.0.1:3000/change_documents/instances/page/{page_id + 1}"
-    )
+    assert change_set.prev == f"{CHANGE_DOCUMENTS_URL}/instances/page/{page_id - 1}"
+    assert change_set.next == f"{CHANGE_DOCUMENTS_URL}/instances/page/{page_id + 1}"
 
     assert change_set.orderedItems[0].type == "Update"
     assert change_set.orderedItems[0].object.type == f"bf:{BibframeType.INSTANCE}"

--- a/tests/change_documents/test_entry_point.py
+++ b/tests/change_documents/test_entry_point.py
@@ -14,7 +14,7 @@ import pytest
 
 
 TEST_PAGE_LENGTH = 2
-HOST = "http://127.0.0.1:3000"
+CHANGE_DOCUMENTS_URL = "https://bcld.info/api/change_documents"
 
 
 def add_works(db: Session, start_index: int) -> None:
@@ -81,13 +81,11 @@ def test_work_entry_point_add(client: TestClient, db_session: Session) -> None:
     entry_point = EntryPoint(
         db=db_session,
         bc_type=BluecoreType.WORKS,
-        host=HOST,
+        change_documents_url=CHANGE_DOCUMENTS_URL,
         page_length=TEST_PAGE_LENGTH,
     )
     assert entry_point.totalItems == 4
-    assert (
-        entry_point.last["id"] == "http://127.0.0.1:3000/change_documents/works/page/2"
-    )
+    assert entry_point.last["id"] == f"{CHANGE_DOCUMENTS_URL}/works/page/2"
 
     response = client.get("/change_documents/works/feed")
     assert response.status_code == 200
@@ -104,13 +102,11 @@ def test_work_entry_point_update(client: TestClient, db_session: Session) -> Non
     entry_point = EntryPoint(
         db=db_session,
         bc_type=BluecoreType.WORKS,
-        host=HOST,
+        change_documents_url=CHANGE_DOCUMENTS_URL,
         page_length=TEST_PAGE_LENGTH,
     )
     assert entry_point.totalItems == 6
-    assert (
-        entry_point.last["id"] == "http://127.0.0.1:3000/change_documents/works/page/3"
-    )
+    assert entry_point.last["id"] == f"{CHANGE_DOCUMENTS_URL}/works/page/3"
 
 
 def test_instance_entry_point_add(client: TestClient, db_session: Session) -> None:
@@ -122,14 +118,11 @@ def test_instance_entry_point_add(client: TestClient, db_session: Session) -> No
     entry_point = entry_point = EntryPoint(
         db=db_session,
         bc_type=BluecoreType.INSTANCES,
-        host=HOST,
+        change_documents_url=CHANGE_DOCUMENTS_URL,
         page_length=TEST_PAGE_LENGTH,
     )
     assert entry_point.totalItems == 4
-    assert (
-        entry_point.last["id"]
-        == "http://127.0.0.1:3000/change_documents/instances/page/2"
-    )
+    assert entry_point.last["id"] == f"{CHANGE_DOCUMENTS_URL}/instances/page/2"
 
 
 def test_instance_entry_point_update(client: TestClient, db_session: Session) -> None:
@@ -143,14 +136,11 @@ def test_instance_entry_point_update(client: TestClient, db_session: Session) ->
     entry_point = entry_point = EntryPoint(
         db=db_session,
         bc_type=BluecoreType.INSTANCES,
-        host=HOST,
+        change_documents_url=CHANGE_DOCUMENTS_URL,
         page_length=TEST_PAGE_LENGTH,
     )
     assert entry_point.totalItems == 8
-    assert (
-        entry_point.last["id"]
-        == "http://127.0.0.1:3000/change_documents/instances/page/4"
-    )
+    assert entry_point.last["id"] == f"{CHANGE_DOCUMENTS_URL}/instances/page/4"
 
     response = client.get("/change_documents/instances/feed")
     assert response.status_code == 200

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,6 @@ os.environ["API_KEYCLOAK_CLIENT_ID"] = "bluecore"
 os.environ["API_KEYCLOAK_CLIENT_SECRET"] = "abcded235"
 
 os.environ["ACTIVITY_STREAMS_PAGE_LENGTH"] = "2"
-os.environ["ACTIVITY_STREAMS_HOST"] = "http://127.0.0.1:3000"
 
 
 @pytest.fixture(scope="session")

--- a/uv.lock
+++ b/uv.lock
@@ -59,7 +59,7 @@ wheels = [
 
 [[package]]
 name = "bluecore-api"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "bluecore-models" },


### PR DESCRIPTION
## Why was this change made?
For production, the URL pattern should be https://bcld.info/**api**/change_documents.
It now uses its own CHANGE_DOCUMENTS_URL env var which defaults to the production value.


## How was this change tested?
pytest and locally running


## Which documentation and/or configurations were updated?
N/A



