### PR TITLE
122/fix incorrect activity stream page url 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-api"
-version = "0.6.0"
+version = "0.6.1"
 description = "Blue Core API for managing BIBFRAME RDF data and workflows"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/bluecore_api/change_documents/change_set.py
+++ b/src/bluecore_api/change_documents/change_set.py
@@ -103,8 +103,8 @@ class ChangeSet(Counter, ChangeSetSchema):
             ordered_items.append(EntityChangeActivity(version=version))
 
         super().__init__(
-            id=f"{host}/change_documents/{bc_type}/page/{id}",
-            partOf=f"{host}/change_documents/{bc_type}/feed",
+            id=f"{host}/api/change_documents/{bc_type}/page/{id}",
+            partOf=f"{host}/api/change_documents/{bc_type}/feed",
             prev=prev_next["prev"],
             next=prev_next["next"],
             orderedItems=ordered_items,
@@ -126,12 +126,12 @@ class ChangeSet(Counter, ChangeSetSchema):
         if prev_id < 1:
             prev = None
         else:
-            prev = f"{host}/change_documents/{bc_type}/page/{prev_id}"
+            prev = f"{host}/api/change_documents/{bc_type}/page/{prev_id}"
 
         next_id = id + 1
         if next_id > total_pages:
             next = None
         else:
-            next = f"{host}/change_documents/{bc_type}/page/{next_id}"
+            next = f"{host}/api/change_documents/{bc_type}/page/{next_id}"
 
         return {"prev": prev, "next": next}

--- a/src/bluecore_api/change_documents/entry_point.py
+++ b/src/bluecore_api/change_documents/entry_point.py
@@ -15,14 +15,14 @@ class EntryPoint(Counter, EntryPointSchema):
         last_page: int = math.ceil(total / page_length)
         super().__init__(
             summary="Bluecore Activity Streams Entry Point",
-            id=f"{host}/change_documents/{bc_type}/feed",
+            id=f"{host}/api/change_documents/{bc_type}/feed",
             totalItems=total,
             first={
-                "id": f"{host}/change_documents/{bc_type}/page/1",
+                "id": f"{host}/api/change_documents/{bc_type}/page/1",
                 "type": "OrderedCollectionPage",
             },
             last={
-                "id": f"{host}/change_documents/{bc_type}/page/{last_page}",
+                "id": f"{host}/api/change_documents/{bc_type}/page/{last_page}",
                 "type": "OrderedCollectionPage",
             },
         )

--- a/src/bluecore_api/change_documents/routes.py
+++ b/src/bluecore_api/change_documents/routes.py
@@ -13,7 +13,7 @@ import os
 page_length: int = int(
     os.getenv("ACTIVITY_STREAMS_PAGE_LENGTH", DEFAULT_ACTIVITY_STREAMS_PAGE_LENGTH)
 )
-host: str = os.getenv("BLUECORE_URL", "http://127.0.0.1:3000").rstrip("/")
+host: str = os.getenv("BLUECORE_URL", "https://bcld.info").rstrip("/")
 
 change_documents = APIRouter()
 

--- a/tests/change_documents/test_change_set.py
+++ b/tests/change_documents/test_change_set.py
@@ -14,7 +14,7 @@ import pytest
 
 
 TEST_PAGE_LENGTH = 2
-HOST = "http://127.0.0.1:3000"
+BLUECORE_URL = "https://bcld.info"
 
 
 def add_works(db: Session, start_index: int) -> None:
@@ -84,18 +84,19 @@ def test_work_change_set_add(client: TestClient, db_session: Session) -> None:
         db=db_session,
         bc_type=BluecoreType.WORKS,
         id=page_id,
-        host=HOST,
+        host=BLUECORE_URL,
         page_length=TEST_PAGE_LENGTH,
     )
     assert change_set.totalItems == 2
     assert change_set.prev is None
     assert (
         change_set.next
-        == f"http://127.0.0.1:3000/change_documents/works/page/{page_id + 1}"
+        == f"{BLUECORE_URL}/api/change_documents/works/page/{page_id + 1}"
     )
     assert change_set.orderedItems[0].type == "Create"
     assert change_set.orderedItems[0].object.type == f"bf:{BibframeType.WORK}"
 
+    # The client should use the default value for CHANGE_DOCUMENTS_URL
     response = client.get(f"/change_documents/works/page/{page_id}")
     assert response.status_code == 200
     as_schema = ChangeSetSchema.model_validate(change_set)
@@ -113,13 +114,13 @@ def test_work_entry_point_update(client: TestClient, db_session: Session) -> Non
         db=db_session,
         bc_type=BluecoreType.WORKS,
         id=page_id,
-        host=HOST,
+        host=BLUECORE_URL,
         page_length=TEST_PAGE_LENGTH,
     )
     assert change_set.totalItems == 2
     assert (
         change_set.prev
-        == f"http://127.0.0.1:3000/change_documents/works/page/{page_id - 1}"
+        == f"{BLUECORE_URL}/api/change_documents/works/page/{page_id - 1}"
     )
     assert change_set.next is None
     assert change_set.orderedItems[0].type == "Update"
@@ -137,13 +138,13 @@ def test_instance_entry_point_add(client: TestClient, db_session: Session) -> No
         db=db_session,
         bc_type=BluecoreType.INSTANCES,
         id=page_id,
-        host=HOST,
+        host=BLUECORE_URL,
         page_length=TEST_PAGE_LENGTH,
     )
     assert change_set.totalItems == 2
     assert (
         change_set.prev
-        == f"http://127.0.0.1:3000/change_documents/instances/page/{page_id - 1}"
+        == f"{BLUECORE_URL}/api/change_documents/instances/page/{page_id - 1}"
     )
     assert change_set.next is None
     assert change_set.orderedItems[0].type == "Create"
@@ -162,7 +163,7 @@ def test_instance_entry_point_update(client: TestClient, db_session: Session) ->
         db=db_session,
         bc_type=BluecoreType.INSTANCES,
         id=1,
-        host=HOST,
+        host=BLUECORE_URL,
         page_length=TEST_PAGE_LENGTH,
     )
     assert change_set.orderedItems[0].type == "Create"
@@ -173,17 +174,17 @@ def test_instance_entry_point_update(client: TestClient, db_session: Session) ->
         db=db_session,
         bc_type=BluecoreType.INSTANCES,
         id=page_id,
-        host=HOST,
+        host=BLUECORE_URL,
         page_length=TEST_PAGE_LENGTH,
     )
     assert change_set.totalItems == 2
     assert (
         change_set.prev
-        == f"http://127.0.0.1:3000/change_documents/instances/page/{page_id - 1}"
+        == f"{BLUECORE_URL}/api/change_documents/instances/page/{page_id - 1}"
     )
     assert (
         change_set.next
-        == f"http://127.0.0.1:3000/change_documents/instances/page/{page_id + 1}"
+        == f"{BLUECORE_URL}/api/change_documents/instances/page/{page_id + 1}"
     )
 
     assert change_set.orderedItems[0].type == "Update"

--- a/tests/change_documents/test_entry_point.py
+++ b/tests/change_documents/test_entry_point.py
@@ -14,7 +14,7 @@ import pytest
 
 
 TEST_PAGE_LENGTH = 2
-HOST = "http://127.0.0.1:3000"
+BLUECORE_URL = "https://bcld.info"
 
 
 def add_works(db: Session, start_index: int) -> None:
@@ -81,13 +81,11 @@ def test_work_entry_point_add(client: TestClient, db_session: Session) -> None:
     entry_point = EntryPoint(
         db=db_session,
         bc_type=BluecoreType.WORKS,
-        host=HOST,
+        host=BLUECORE_URL,
         page_length=TEST_PAGE_LENGTH,
     )
     assert entry_point.totalItems == 4
-    assert (
-        entry_point.last["id"] == "http://127.0.0.1:3000/change_documents/works/page/2"
-    )
+    assert entry_point.last["id"] == f"{BLUECORE_URL}/api/change_documents/works/page/2"
 
     response = client.get("/change_documents/works/feed")
     assert response.status_code == 200
@@ -104,13 +102,11 @@ def test_work_entry_point_update(client: TestClient, db_session: Session) -> Non
     entry_point = EntryPoint(
         db=db_session,
         bc_type=BluecoreType.WORKS,
-        host=HOST,
+        host=BLUECORE_URL,
         page_length=TEST_PAGE_LENGTH,
     )
     assert entry_point.totalItems == 6
-    assert (
-        entry_point.last["id"] == "http://127.0.0.1:3000/change_documents/works/page/3"
-    )
+    assert entry_point.last["id"] == f"{BLUECORE_URL}/api/change_documents/works/page/3"
 
 
 def test_instance_entry_point_add(client: TestClient, db_session: Session) -> None:
@@ -122,13 +118,13 @@ def test_instance_entry_point_add(client: TestClient, db_session: Session) -> No
     entry_point = entry_point = EntryPoint(
         db=db_session,
         bc_type=BluecoreType.INSTANCES,
-        host=HOST,
+        host=BLUECORE_URL,
         page_length=TEST_PAGE_LENGTH,
     )
     assert entry_point.totalItems == 4
     assert (
         entry_point.last["id"]
-        == "http://127.0.0.1:3000/change_documents/instances/page/2"
+        == f"{BLUECORE_URL}/api/change_documents/instances/page/2"
     )
 
 
@@ -143,13 +139,13 @@ def test_instance_entry_point_update(client: TestClient, db_session: Session) ->
     entry_point = entry_point = EntryPoint(
         db=db_session,
         bc_type=BluecoreType.INSTANCES,
-        host=HOST,
+        host=BLUECORE_URL,
         page_length=TEST_PAGE_LENGTH,
     )
     assert entry_point.totalItems == 8
     assert (
         entry_point.last["id"]
-        == "http://127.0.0.1:3000/change_documents/instances/page/4"
+        == f"{BLUECORE_URL}/api/change_documents/instances/page/4"
     )
 
     response = client.get("/change_documents/instances/feed")

--- a/uv.lock
+++ b/uv.lock
@@ -59,7 +59,7 @@ wheels = [
 
 [[package]]
 name = "bluecore-api"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "bluecore-models" },


### PR DESCRIPTION
## Why was this change made?
Add /api prefix for all URL outputs of change_documents


## How was this change tested?
Locally & pytest


## Which documentation and/or configurations were updated?
N/A



