### PR TITLE
Replaces colons with ampersand

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-api"
-version = "0.6.4"
+version = "0.6.5"
 description = "Blue Core API for managing BIBFRAME RDF data and workflows"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/bluecore_api/app/routes/search.py
+++ b/src/bluecore_api/app/routes/search.py
@@ -42,6 +42,7 @@ def format_query(query: str) -> str:
     formatted = OR_MAPPER.sub("__OR__", formatted)
     return (
         formatted.replace(" ", " & ")
+        .replace(":", " & ")
         .replace("__OR__", " | ")
         .replace("__PH__", " <-> ")
         .replace("*", ":*")

--- a/tests/api/test_search.py
+++ b/tests/api/test_search.py
@@ -23,6 +23,10 @@ def test_format_query():
         format_query('test "hello world" | "phrase search terms"')
         == "test & hello <-> world | phrase <-> search <-> terms"
     )
+    assert (
+        format_query("bluecore:bf2:Monograph:Work")
+        == "bluecore & bf2 & Monograph & Work"
+    )
 
 
 test_work_uuid = "370ccc0a-3280-4036-9ca1-d9b5d5daf7df"

--- a/uv.lock
+++ b/uv.lock
@@ -59,7 +59,7 @@ wheels = [
 
 [[package]]
 name = "bluecore-api"
-version = "0.6.4"
+version = "0.6.5"
 source = { editable = "." }
 dependencies = [
     { name = "bluecore-models" },


### PR DESCRIPTION
## Why was this change made?
Sinopia stores template names that contain a number colons, i.e. `bluecore:bf2:Monograph:Work` which are indexed with the colons removed. This replaces the `:` with " & " in the query string.


## How was this change tested?
unit test


## Which documentation and/or configurations were updated?
`pyproject.toml`



