### PR TITLE
Dev cors and cbd auth fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-api"
-version = "0.7.1"
+version = "0.7.2"
 description = "Blue Core API for managing BIBFRAME RDF data and workflows"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/bluecore_api/app/main.py
+++ b/src/bluecore_api/app/main.py
@@ -53,6 +53,12 @@ async def scope_mapper(claim_auth: list) -> list:
 """Auth or dev mode config"""
 if os.getenv("DEVELOPER_MODE") == "true":
     enable_developer_mode(base_app)
+    base_app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],  # Allows for any local client to connect
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
     application = base_app
 else:
     keycloak_config = KeycloakConfiguration(

--- a/src/bluecore_api/app/main.py
+++ b/src/bluecore_api/app/main.py
@@ -85,6 +85,7 @@ base_app.add_middleware(
     allow_headers=["*"],
 )
 
+
 @base_app.get("/")
 async def index():
     """Public route for API root."""

--- a/src/bluecore_api/app/main.py
+++ b/src/bluecore_api/app/main.py
@@ -53,12 +53,6 @@ async def scope_mapper(claim_auth: list) -> list:
 """Auth or dev mode config"""
 if os.getenv("DEVELOPER_MODE") == "true":
     enable_developer_mode(base_app)
-    base_app.add_middleware(
-        CORSMiddleware,
-        allow_origins=["*"],  # Allows for any local client to connect
-        allow_methods=["*"],
-        allow_headers=["*"],
-    )
     application = base_app
 else:
     keycloak_config = KeycloakConfiguration(
@@ -82,14 +76,14 @@ else:
         app=base_app, keycloak_middleware=keycloak_middleware
     )
     application = CompatibleFastAPI(app=middleware_wrapped_app)
-    base_app.add_middleware(
-        CORSMiddleware,
-        allow_origins=["*"],  # Allows for any local client to connect
-        allow_methods=["*"],
-        allow_headers=["*"],
-    )
     base_app.add_middleware(RedirectLocationMiddleware)
 
+base_app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # Allows for any local client to connect
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 @base_app.get("/")
 async def index():

--- a/src/bluecore_api/middleware/keycloak_auth.py
+++ b/src/bluecore_api/middleware/keycloak_auth.py
@@ -52,6 +52,7 @@ class BypassKeycloakForGet:
         "/api/change_documents/",
         "/search",
         "/api/search",
+        "/api/cbd"
     }
 
     def __init__(self, app, keycloak_middleware):

--- a/src/bluecore_api/middleware/keycloak_auth.py
+++ b/src/bluecore_api/middleware/keycloak_auth.py
@@ -52,7 +52,7 @@ class BypassKeycloakForGet:
         "/api/change_documents/",
         "/search",
         "/api/search",
-        "/api/cbd"
+        "/api/cbd",
     }
 
     def __init__(self, app, keycloak_middleware):

--- a/uv.lock
+++ b/uv.lock
@@ -59,7 +59,7 @@ wheels = [
 
 [[package]]
 name = "bluecore-api"
-version = "0.7.1"
+version = "0.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "bluecore-models" },


### PR DESCRIPTION
## Why was this change made?
* Added `cbd` GET endpoint to bypass keycloak auth
* Updated CORs policy to work in dev mode too


## How was this change tested?
Tested locally to ensure Marva communication locally


## Which documentation and/or configurations were updated?
n/a



