### PR TITLE
Use original query string in generated links while also applying urlencode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-api"
-version = "0.9.3"
+version = "0.9.4"
 description = "Blue Core API for managing BIBFRAME RDF data and workflows"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/api/test_search.py
+++ b/tests/api/test_search.py
@@ -74,6 +74,10 @@ def test_search(client: TestClient, db_session: Session):
     assert len(result["results"]) == 1
     assert result["results"][0]["uri"].startswith(test_work_bluecore_uri)
     assert result["total"] == 1
+    assert (
+        result["links"]["first"]
+        == "https://bcld.info/api/search/?limit=10&offset=0&q=kumae+chedo+mit&type=all"
+    )
 
 
 def test_or_search(client: TestClient, db_session: Session):
@@ -84,6 +88,9 @@ def test_or_search(client: TestClient, db_session: Session):
     assert len(result["results"]) == 1
     assert result["results"][0]["uri"].startswith(test_work_bluecore_uri)
     assert result["total"] == 1
+    assert result["links"]["first"] == (
+        "https://bcld.info/api/search/?limit=10&offset=0&q=kumae+chedo+mi+%7C+mit&type=all"
+    )
 
 
 def test_phrase_search(client: TestClient, db_session: Session):
@@ -104,6 +111,9 @@ def test_wildcard_search(client: TestClient, db_session: Session):
     assert len(result["results"]) == 1
     assert result["results"][0]["uri"].startswith(test_work_bluecore_uri)
     assert result["total"] == 1
+    assert result["links"]["first"] == (
+        "https://bcld.info/api/search/?limit=10&offset=0&q=kumae+chedo+mi%2A&type=all"
+    )
 
 
 def test_search_incomplete_word(client: TestClient, db_session: Session):
@@ -123,6 +133,10 @@ def test_search_works(client: TestClient, db_session: Session):
     assert len(result["results"]) == 1
     assert result["results"][0]["uri"].startswith(test_work_bluecore_uri)
     assert result["total"] == 1
+    assert (
+        result["links"]["first"]
+        == "https://bcld.info/api/search/?limit=10&offset=0&q=kumae+chedo+mit&type=works"
+    )
 
 
 def test_search_instances(client: TestClient, db_session: Session):
@@ -167,6 +181,10 @@ def test_search_profile(client: TestClient, db_session: Session):
     assert len(result["results"]) == 2
     assert result["results"][0]["uri"] == "https://api.sinopia.io/profiles/test-profile"
     assert result["total"] == 2
+    assert (
+        result["links"]["first"]
+        == "https://bcld.info/api/search/profile/?limit=10&offset=0&q=id.loc.gov%2Fontologies%2Fbibframe%2Flanguage"
+    )
 
 
 def test_search_profile_limit(client: TestClient, db_session: Session):

--- a/uv.lock
+++ b/uv.lock
@@ -59,7 +59,7 @@ wheels = [
 
 [[package]]
 name = "bluecore-api"
-version = "0.9.3"
+version = "0.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "bluecore-models" },


### PR DESCRIPTION
## Why was this change made?
Fix a bug where the generated links would show the postgres formatted query string.
e.g. for searching "City firefighters", we currently get "City & firefighters" in the links as query where it should have been "City+firefighters".
[https://dev.bcld.info/api/search/?limit=10&offset=0&q=City & firefighters&type=instances](https://dev.bcld.info/api/search/?limit=10&offset=0&q=City%20&%20firefighters&type=instances)

## How was this change tested?
locally/pytest


## Which documentation and/or configurations were updated?
N/A



