### PR TITLE
#76 add content negotiation for instance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-api"
-version = "0.13.0"
+version = "0.14.0"
 description = "Blue Core API for managing BIBFRAME RDF data and workflows"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/bluecore_api/app/routes/cbd.py
+++ b/src/bluecore_api/app/routes/cbd.py
@@ -1,41 +1,20 @@
-import copy
-import json
+#################################################################################################################################
+## Deprecated: The instances endpoint now supports content negotiation and can return CBD JSON-LD or XML based on the request. ##
+## The separate CBD endpoint is no longer needed and will be removed in a future release.                                      ##
+#################################################################################################################################
 
 from fastapi import APIRouter, Depends, HTTPException, Response
-from lxml import etree
-from rdflib import Graph, Namespace
 from sqlalchemy.orm import Session
-from typing import Any
 
+from bluecore_api.app.utils.serializer.cbd import (
+    generate_cbd_jsonld_response,
+    generate_cbd_xml_response,
+)
 from bluecore_api.database import get_db
-from bluecore_api.constants import BibframeType
-from bluecore_api.expansion import expand_resource_as_graph
 from bluecore_models.models import Instance
-from bluecore_models.utils.graph import load_jsonld
 
 
 endpoints = APIRouter()
-
-BF_NAMESPACE = Namespace("http://id.loc.gov/ontologies/bibframe/")
-RDF_NAMESPACE = Namespace("http://www.w3.org/1999/02/22-rdf-syntax-ns#")
-XPATH_NAMESPACES = {
-    "bf": str(BF_NAMESPACE),
-    "rdf": str(RDF_NAMESPACE),
-}
-
-
-def reorder_work_types(work_data: dict[str, Any]) -> dict[str, Any]:
-    """Reorder work types to ensure 'Work' is first"""
-    if isinstance(work_data.get("@type"), list):
-        work_data["@type"].sort(key=lambda x: x != BibframeType.WORK)  # type: ignore
-    return work_data
-
-
-def reorder_instance_types(instance_data: dict[str, Any]) -> dict[str, Any]:
-    """Reorder instance types to ensure 'Instance' is first"""
-    if isinstance(instance_data.get("@type"), list):
-        instance_data["@type"].sort(key=lambda x: x != BibframeType.INSTANCE)  # type: ignore
-    return instance_data
 
 
 @endpoints.get("/cbd/{instance_uuid}", operation_id="get_cbd")
@@ -47,97 +26,7 @@ async def cbd(instance_uuid: str, db: Session = Depends(get_db)) -> Response:
     if db_instance is None:
         raise HTTPException(status_code=404, detail="Instance not found")
 
-    instance_graph = generate_cbd_graph(db_instance)
-
     if instance_uuid.endswith(".jsonld"):
-        jsonld_content = instance_graph.serialize(format="json-ld", indent=2)
-        return Response(
-            content=jsonld_content,
-            media_type="application/json",
-        )
+        return generate_cbd_jsonld_response(db_instance)
 
-    instance_root = generate_cbd_xml(instance_graph)
-    xml_content = etree.tostring(instance_root, encoding="utf-8").decode("utf-8")
-    return Response(
-        content=xml_content,
-        media_type="application/rdf+xml",
-    )
-
-
-def generate_cbd_graph(instance: Instance) -> Graph:
-    """
-    Generate a CBD graph for a given Instance.
-    It includes the Instance, its Work, and any other Instances of that Work, along with their related resources.
-
-    Args:
-        instance (Instance): The Instance for which to generate the CBD graph
-
-    Returns:
-        Graph: RDF graph containing the CBD for the given Instance
-    """
-    instance.data = reorder_instance_types(instance.data)
-    instance_graph: Graph = load_jsonld(instance.data)
-    instance_graph = expand_resource_as_graph(instance, instance_graph)
-
-    work = instance.work
-    # The xml serialization uses the first @type to determine the root element
-    # Make sure 'Work' is the first in the list of types for the work
-    work.data = reorder_work_types(work.data)
-    instance_graph.parse(data=json.dumps(work.data), format="json-ld")
-    instance_graph = expand_resource_as_graph(work, instance_graph)
-
-    uuid = str(instance.uuid)
-    # If the work has multiple instances, include them in the graph
-    for related_instance in work.instances:
-        if uuid != str(related_instance.uuid):
-            related_instance.data = reorder_instance_types(related_instance.data)
-            instance_graph.parse(
-                data=json.dumps(related_instance.data), format="json-ld"
-            )
-            instance_graph = expand_resource_as_graph(related_instance, instance_graph)
-
-    instance_graph.bind("bf", BF_NAMESPACE, override=True, replace=True)
-    return instance_graph
-
-
-def generate_cbd_xml(graph: Graph):
-    """
-    Generate CBD XML representation.
-    The pretty-xml format generates all other resources at the same level as Work/Instance(s).
-    Marva cannot parse this format properly.
-    This method reorders the XML so that the related resources are nested within Work/Instance(s).
-
-    Args:
-        graph (Graph): CBD graph
-
-    Returns:
-        lxml root element for the CBD XML
-    """
-    root = etree.fromstring(
-        graph.serialize(format="pretty-xml", indent=2, max_depth=1).encode("utf-8")
-    )
-    for elem in root:
-        if elem.tag.endswith(BibframeType.WORK) or elem.tag.endswith(
-            BibframeType.INSTANCE
-        ):
-            continue
-
-        about = elem.xpath("@rdf:about", namespaces=XPATH_NAMESPACES)
-        if not about:
-            continue
-
-        matches = root.findall(
-            f".//*[@rdf:resource='{about[0]}']", namespaces=XPATH_NAMESPACES
-        )
-        for match in matches:
-            etree.strip_attributes(match, f"{{{RDF_NAMESPACE}}}resource")
-            match.append(copy.deepcopy(elem))
-
-    for elem in root:
-        if elem.tag.endswith(BibframeType.WORK) or elem.tag.endswith(
-            BibframeType.INSTANCE
-        ):
-            continue
-        root.remove(elem)
-
-    return root
+    return generate_cbd_xml_response(db_instance)

--- a/src/bluecore_api/app/routes/instances.py
+++ b/src/bluecore_api/app/routes/instances.py
@@ -2,15 +2,19 @@ import json
 import os
 from datetime import UTC, datetime
 
+
 from pymilvus import MilvusClient
 
 from bluecore_models.models import Instance
 from bluecore_models.utils.graph import handle_external_subject
 from bluecore_models.utils.vector_db import create_embeddings
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi_keycloak_middleware import CheckPermissions
 from sqlalchemy.orm import Session
 
+from bluecore_api.app.utils.serializer.instance_serializer import (
+    serialize_instance,
+)
 from bluecore_api.database import filter_vector_result, get_db, get_vector_client
 from bluecore_api.schemas.schemas import (
     InstanceCreateSchema,
@@ -31,12 +35,21 @@ BLUECORE_URL = os.environ.get("BLUECORE_URL", "https://bcld.info/")
     operation_id="get_instance",
 )
 async def read_instance(
-    instance_uuid: str, expand: bool = False, db: Session = Depends(get_db)
-):
+    instance_uuid: str,
+    request: Request,
+    expand: bool = False,
+    format: str | None = None,
+    db: Session = Depends(get_db),
+) -> Response | Instance:
     db_instance = db.query(Instance).filter(Instance.uuid == instance_uuid).first()
 
     if db_instance is None:
         raise HTTPException(status_code=404, detail="Instance not found")
+
+    resp: Response | None = serialize_instance(db_instance, format, request)
+    if resp:
+        return resp
+
     if expand:
         db_instance.data = expand_resource_graph(db_instance)
     setattr(db_instance, "is_expanded", expand)

--- a/src/bluecore_api/app/routes/instances.py
+++ b/src/bluecore_api/app/routes/instances.py
@@ -2,7 +2,6 @@ import json
 import os
 from datetime import UTC, datetime
 
-
 from pymilvus import MilvusClient
 
 from bluecore_models.models import Instance

--- a/src/bluecore_api/app/utils/serializer/cbd.py
+++ b/src/bluecore_api/app/utils/serializer/cbd.py
@@ -1,0 +1,132 @@
+import copy
+import json
+
+from fastapi import Response
+from lxml import etree
+from rdflib import Graph, Namespace
+from typing import Any
+
+from bluecore_api.constants import BibframeType
+from bluecore_api.expansion import expand_resource_as_graph
+from bluecore_models.models import Instance
+from bluecore_models.utils.graph import load_jsonld
+
+
+BF_NAMESPACE = Namespace("http://id.loc.gov/ontologies/bibframe/")
+RDF_NAMESPACE = Namespace("http://www.w3.org/1999/02/22-rdf-syntax-ns#")
+XPATH_NAMESPACES = {
+    "bf": str(BF_NAMESPACE),
+    "rdf": str(RDF_NAMESPACE),
+}
+
+
+def reorder_work_types(work_data: dict[str, Any]) -> dict[str, Any]:
+    """Reorder work types to ensure 'Work' is first"""
+    if isinstance(work_data.get("@type"), list):
+        work_data["@type"].sort(key=lambda x: x != BibframeType.WORK)  # type: ignore
+    return work_data
+
+
+def reorder_instance_types(instance_data: dict[str, Any]) -> dict[str, Any]:
+    """Reorder instance types to ensure 'Instance' is first"""
+    if isinstance(instance_data.get("@type"), list):
+        instance_data["@type"].sort(key=lambda x: x != BibframeType.INSTANCE)  # type: ignore
+    return instance_data
+
+
+def generate_cbd_graph(instance: Instance) -> Graph:
+    """
+    Generate a CBD graph for a given Instance.
+    It includes the Instance, its Work, and any other Instances of that Work, along with their related resources.
+
+    Args:
+        instance (Instance): The Instance for which to generate the CBD graph
+
+    Returns:
+        Graph: RDF graph containing the CBD for the given Instance
+    """
+    instance.data = reorder_instance_types(instance.data)
+    instance_graph: Graph = load_jsonld(instance.data)
+    instance_graph = expand_resource_as_graph(instance, instance_graph)
+
+    work = instance.work
+    # The xml serialization uses the first @type to determine the root element
+    # Make sure 'Work' is the first in the list of types for the work
+    work.data = reorder_work_types(work.data)
+    instance_graph.parse(data=json.dumps(work.data), format="json-ld")
+    instance_graph = expand_resource_as_graph(work, instance_graph)
+
+    uuid = str(instance.uuid)
+    # If the work has multiple instances, include them in the graph
+    for related_instance in work.instances:
+        if uuid != str(related_instance.uuid):
+            related_instance.data = reorder_instance_types(related_instance.data)
+            instance_graph.parse(
+                data=json.dumps(related_instance.data), format="json-ld"
+            )
+            instance_graph = expand_resource_as_graph(related_instance, instance_graph)
+
+    instance_graph.bind("bf", BF_NAMESPACE, override=True, replace=True)
+    return instance_graph
+
+
+def generate_cbd_xml(graph: Graph):
+    """
+    Generate CBD XML representation.
+    The pretty-xml format generates all other resources at the same level as Work/Instance(s).
+    Marva cannot parse this format properly.
+    This method reorders the XML so that the related resources are nested within Work/Instance(s).
+
+    Args:
+        graph (Graph): CBD graph
+
+    Returns:
+        lxml root element for the CBD XML
+    """
+    root = etree.fromstring(
+        graph.serialize(format="pretty-xml", indent=2, max_depth=1).encode("utf-8")
+    )
+    for elem in root:
+        if elem.tag.endswith(BibframeType.WORK) or elem.tag.endswith(
+            BibframeType.INSTANCE
+        ):
+            continue
+
+        about = elem.xpath("@rdf:about", namespaces=XPATH_NAMESPACES)
+        if not about:
+            continue
+
+        matches = root.findall(
+            f".//*[@rdf:resource='{about[0]}']", namespaces=XPATH_NAMESPACES
+        )
+        for match in matches:
+            etree.strip_attributes(match, f"{{{RDF_NAMESPACE}}}resource")
+            match.append(copy.deepcopy(elem))
+
+    for elem in root:
+        if elem.tag.endswith(BibframeType.WORK) or elem.tag.endswith(
+            BibframeType.INSTANCE
+        ):
+            continue
+        root.remove(elem)
+
+    return root
+
+
+def generate_cbd_jsonld_response(instance: Instance) -> Response:
+    instance_graph = generate_cbd_graph(instance)
+    jsonld_content = instance_graph.serialize(format="json-ld", indent=2)
+    return Response(
+        content=jsonld_content,
+        media_type="application/ld+json",
+    )
+
+
+def generate_cbd_xml_response(instance: Instance) -> Response:
+    instance_graph = generate_cbd_graph(instance)
+    instance_root = generate_cbd_xml(instance_graph)
+    xml_content = etree.tostring(instance_root, encoding="utf-8").decode("utf-8")
+    return Response(
+        content=xml_content,
+        media_type="application/rdf+xml",
+    )

--- a/src/bluecore_api/app/utils/serializer/instance_serializer.py
+++ b/src/bluecore_api/app/utils/serializer/instance_serializer.py
@@ -1,0 +1,32 @@
+from typing import Callable
+
+from fastapi import Request, Response
+
+from bluecore_api.app.utils.serializer.cbd import (
+    generate_cbd_jsonld_response,
+    generate_cbd_xml_response,
+)
+from bluecore_models.models import Instance
+
+type InstanceSerializerFn = Callable[[Instance], Response]
+instance_serializer_format_registry: dict[str, InstanceSerializerFn] = {
+    "cbdjsonld": generate_cbd_jsonld_response,
+    "cbdxml": generate_cbd_xml_response,
+}
+instance_serializer_accept_registry: dict[str, InstanceSerializerFn] = {
+    "application/cbd+jsonld": generate_cbd_jsonld_response,
+    "application/cbd+xml": generate_cbd_xml_response,
+}
+
+
+def serialize_instance(
+    instance: Instance, format: str | None, request: Request
+) -> Response | None:
+    if format in instance_serializer_format_registry:
+        return instance_serializer_format_registry[format](instance)
+    accept_header = request.headers.get("accept", "")
+    for accept in accept_header.split(","):
+        accept = accept.strip()
+        if accept in instance_serializer_accept_registry:
+            return instance_serializer_accept_registry[accept](instance)
+    return None

--- a/tests/api/test_cbd.py
+++ b/tests/api/test_cbd.py
@@ -9,7 +9,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 from typing import Any
 
-from bluecore_api.app.routes.cbd import (
+from bluecore_api.app.utils.serializer.cbd import (
     XPATH_NAMESPACES,
     generate_cbd_graph,
     generate_cbd_xml,
@@ -98,7 +98,8 @@ def test_cbd(client: TestClient, db_session: Session):
     work_derived_from: str = work.data["derivedFrom"]["@id"]
     instances = add_instances(client, db_session, work_id, work_derived_from)
 
-    response = client.get(f"/cbd/{str(instances[0].uuid)}.rdf")
+    headers = {"Accept": "application/cbd+xml"}
+    response = client.get(f"/instances/{str(instances[0].uuid)}", headers=headers)
     assert response.status_code == 200
     assert response.headers["Content-Type"] == "application/rdf+xml"
     response_data = response.content.decode("utf-8")
@@ -144,7 +145,8 @@ def test_cbd_other_resources(client: TestClient, db_session: Session):
     instance_uri = next(instance_graph.subjects(RDF.type, BF.Instance))
     uuid = instance_uri.split("/")[-1]
 
-    response = client.get(f"/cbd/{uuid}.rdf")
+    query_params = {"format": "cbdjsonld"}
+    response = client.get(f"/instances/{uuid}", params=query_params)
     response_graph = Graph()
     response_graph.parse(data=response.content, format=response.headers["Content-Type"])
     assert (

--- a/uv.lock
+++ b/uv.lock
@@ -81,7 +81,7 @@ wheels = [
 
 [[package]]
 name = "bluecore-api"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "bluecore-models" },


### PR DESCRIPTION
## Why was this change made?
Allow instances endpoint to deliver multiple output format.
This will allow Marva to load the Blue Core instance URI for CBD XML serialization.
To get that working properly, we need to update our Marva instance to send proper Accept header when requesting a Blue Core URI.
When that update is deployed, we can remove the deprecated cbd endpoint.


## How was this change tested?
Local terraform infrastructure


## Which documentation and/or configurations were updated?
N/A
This content negotiation feature is not reflected in the openapi swagger instances.


