### PR TITLE
Run migrations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,9 @@ WORKDIR /bluecore_api
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 
 COPY --chown=airflow:root src ./src
-COPY --chown=airflow:root pyproject.toml uv.lock README.md ./
+COPY --chown=airflow:root pyproject.toml uv.lock README.md alembic.ini start.sh ./
 
 ENV UV_CACHE_DIR=${AIRFLOW_USER_HOME_DIR}/.cache/uv
 RUN mkdir -p ${UV_CACHE_DIR} && uv sync && uv build && uv pip install dist/*.whl
 
-# run alembic migrations from bluecore-models
-RUN uv run alembic upgrade head
-
-CMD ["uv", "run", "fastapi", "run", "src/bluecore_api/app/main.py", "--port", "8100", "--root-path", "/api"]
+CMD ["./start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,7 @@ COPY --chown=airflow:root pyproject.toml uv.lock README.md ./
 ENV UV_CACHE_DIR=${AIRFLOW_USER_HOME_DIR}/.cache/uv
 RUN mkdir -p ${UV_CACHE_DIR} && uv sync && uv build && uv pip install dist/*.whl
 
+# run alembic migrations from bluecore-models
+RUN uv run alembic upgrade head
+
 CMD ["uv", "run", "fastapi", "run", "src/bluecore_api/app/main.py", "--port", "8100", "--root-path", "/api"]

--- a/README.md
+++ b/README.md
@@ -18,16 +18,6 @@ cd bluecore-workflows
 docker compose up 
 ```
 
-## Database Models
-
-The Blue Core API depends on database models in the [Blue Core Data Models] to be present and up to date.
-
-```shell
-git clone https://github.com/blue-core-lod/bluecore-models
-cd bluecore-models
-uv run alembic upgrade head
-```
- 
 ## 🔧 Environment
 
 Next you will want to clone bluecore_api repository and create a `.env` file that will bring up the application using services that were brought up in the previous step. You should be able to use the following:
@@ -49,6 +39,14 @@ API_KEYCLOAK_PASSWORD="123456"
 # credentials so bluecore_api can talk to airflow
 AIRFLOW_WWW_USER_USERNAME="airflow"
 AIRFLOW_WWW_USER_PASSWORD="airflow"
+```
+
+## Run Migrations
+
+The Docker file will automatically run database migrations from the bluecore-models package for you. But if you are running bluecore_api outside of Docker you will need to apply the migrations:
+
+```shell
+uv run alembic upgrade head
 ```
 
 ## 💾 Uploads Directory

--- a/README.md
+++ b/README.md
@@ -61,11 +61,13 @@ ln -s ../bluecore-workflows/uploads/ uploads
 
 ## 🚀 Running the application
 
-Now you are ready to start the application using your new environment file and the fastapi development server, which will auto-load any changes you make to the code:
+Now you are ready to start the application using your new environment file and the fastapi development server, which will run migrations and auto-load any changes you make to the code:
 
 ```shell
-uv run dotenv run fastapi dev src/bluecore_api/app/main.py --port 3000
+./start.sh
 ```
+
+The application should be available at http://localhost:8100
 
 ## Load Data
 

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,119 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts
+# Use forward slashes (/) also on windows to provide an os agnostic path
+script_location = bluecore_models:migrations
+
+# template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
+# Uncomment the line below if you want the files to be prepended with date and time
+# see https://alembic.sqlalchemy.org/en/latest/tutorial.html#editing-the-ini-file
+# for all available tokens
+# file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s
+
+# sys.path path, will be prepended to sys.path if present.
+# defaults to the current working directory.
+prepend_sys_path = .
+
+# timezone to use when rendering the date within the migration file
+# as well as the filename.
+# If specified, requires the python>=3.9 or backports.zoneinfo library and tzdata library.
+# Any required deps can installed by adding `alembic[tz]` to the pip requirements
+# string value is passed to ZoneInfo()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the "slug" field
+# truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; This defaults
+# to alembic/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path.
+# The path separator used here should be the separator specified by "version_path_separator" below.
+# version_locations = %(here)s/bar:%(here)s/bat:alembic/versions
+
+# version path separator; As mentioned above, this is the character used to split
+# version_locations. The default within new alembic.ini files is "os", which uses os.pathsep.
+# If this key is omitted entirely, it falls back to the legacy behavior of splitting on spaces and/or commas.
+# Valid values for version_path_separator are:
+#
+# version_path_separator = :
+# version_path_separator = ;
+# version_path_separator = space
+# version_path_separator = newline
+#
+# Use os.pathsep. Default configuration used for new projects.
+version_path_separator = os
+
+# set to 'true' to search source files recursively
+# in each "version_locations" directory
+# new in Alembic version 1.10
+# recursive_version_locations = false
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+sqlalchemy.url = postgresql+psycopg2://airflow:airflow@localhost/bluecore
+
+
+[post_write_hooks]
+# post_write_hooks defines scripts or Python functions that are run
+# on newly generated revision scripts.  See the documentation for further
+# detail and examples
+
+# format using "black" - use the console_scripts runner, against the "black" entrypoint
+# hooks = black
+# black.type = console_scripts
+# black.entrypoint = black
+# black.options = -l 79 REVISION_SCRIPT_FILENAME
+
+# lint with attempts to fix using "ruff" - use the exec runner, execute a binary
+# hooks = ruff
+# ruff.type = exec
+# ruff.executable = %(here)s/.venv/bin/ruff
+# ruff.options = --fix REVISION_SCRIPT_FILENAME
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
   "pgvector",
   "psycopg2-binary>=2.9.10",
   "rdflib>=7.1.3",
-  "bluecore-models",
+  "bluecore-models>=0.11.0",
   "python-multipart>=0.0.20",
   "fastapi-keycloak-middleware>=1.2.0",
   "typer>=0.15.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
   "pgvector",
   "psycopg2-binary>=2.9.10",
   "rdflib>=7.1.3",
-  "bluecore-models>=0.11.0",
+  "bluecore-models>=0.11.1",
   "python-multipart>=0.0.20",
   "fastapi-keycloak-middleware>=1.2.0",
   "typer>=0.15.4",

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+uv run alembic upgrade head
+
+uv run fastapi run src/bluecore_api/app/main.py --port 8100 --root-path "/api"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,7 @@
 import pytest
 import pytest_asyncio
 
-import pathlib
 import os
-import random
-import sys
 
 from pytest_mock_resources import PostgresConfig, create_postgres_fixture
 
@@ -161,41 +158,15 @@ def client(mocker, db_session, app):
     Base.metadata.drop_all(bind=db_session.get_bind())
 
 
-root_directory = pathlib.Path(__file__).parent.parent
-dir = root_directory / "src/"
-
-sys.path.append(str(dir))
-
-
 @pytest.fixture
 def vector_client():
+    # bluecore_api.database.get_vector_client() is configured to use this
+    # milvus database when MILVUS_URI is not set
     client = MilvusClient("test-vector.db")
     init_collections(client)
-    # Until milvus-lite PR https://github.com/milvus-io/milvus-lite/pull/303 is part of
-    # release, need to add some data to avoid an exception when trying to query an empty
-    # vector database
-    doc = {"id": 1000, "vector": [random.uniform(-1, 1) for _ in range(768)]}
-    client.insert(
-        "instances",
-        [
-            doc,
-        ],
-    )
-    client.insert(
-        "works",
-        [
-            doc,
-        ],
-    )
 
     yield client
 
+    # on tear down empty collections for the next tests
     client.delete(collection_name="instances", filter="version == 1")
     client.delete(collection_name="works", filter="version == 1")
-
-
-@pytest.fixture(autouse=True)
-def remove_vector_db():
-    vector_db_path = root_directory / "test-vector.db"
-    if vector_db_path.exists():
-        vector_db_path.unlink()

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
@@ -114,7 +114,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bluecore-models" },
+    { name = "bluecore-models", specifier = ">=0.11.1" },
     { name = "fastapi", extras = ["standard"] },
     { name = "fastapi-keycloak-middleware", specifier = ">=1.2.0" },
     { name = "fastapi-mcp", specifier = ">=0.4.0" },
@@ -144,18 +144,19 @@ dev = [
 
 [[package]]
 name = "bluecore-models"
-version = "0.10.1"
+version = "0.11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "alembic" },
     { name = "psycopg2-binary" },
     { name = "pyld" },
-    { name = "pymilvus", extra = ["model"] },
+    { name = "pymilvus", extra = ["milvus-lite", "model"] },
     { name = "rdflib" },
+    { name = "transformers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/86/8f363acf7d4a6e6294a3d132258a63c466841df269db60fd46a97d0a88f1/bluecore_models-0.10.1.tar.gz", hash = "sha256:05845155ad4076486a203f3825799c6013ae00d80bcc925ef53440b8039a711f", size = 102579, upload-time = "2025-10-23T15:49:29.294Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/b5/7638d873fba824c5b2b1047c1cf74615a54b1ed1442ce20da70c402f4673/bluecore_models-0.11.1.tar.gz", hash = "sha256:cc0920891a49ab385ac98ff181d15ccdcaec8aaf76a97e28bffd9b9cfc392ae0", size = 44369, upload-time = "2026-03-05T15:33:35.195Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/a8/87c27a8e15940160fdb45a92c28cd259bfeb429890bae3c8414f3240c675/bluecore_models-0.10.1-py3-none-any.whl", hash = "sha256:c7af88647b77e5527da3d12323e3131273452c678e047fef879425369335d5b0", size = 18130, upload-time = "2025-10-23T15:49:28.156Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2f/0e26fc8827b8b312b22adc90ba46721c4d2a69d0906c3f3a67f600280635/bluecore_models-0.11.1-py3-none-any.whl", hash = "sha256:57e1dc894c2e651273473160b0b58bd8bffc40c7c094421c81b9031c701eebee", size = 25841, upload-time = "2026-03-05T15:33:33.976Z" },
 ]
 
 [[package]]
@@ -2283,7 +2284,7 @@ wheels = [
 
 [[package]]
 name = "transformers"
-version = "4.57.1"
+version = "4.57.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
@@ -2297,9 +2298,9 @@ dependencies = [
     { name = "tokenizers" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d6/68/a39307bcc4116a30b2106f2e689130a48de8bd8a1e635b5e1030e46fcd9e/transformers-4.57.1.tar.gz", hash = "sha256:f06c837959196c75039809636cd964b959f6604b75b8eeec6fdfc0440b89cc55", size = 10142511, upload-time = "2025-10-14T15:39:26.18Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/3a/7c90ee739871495f1a5cb9bdb074b42fe69357d7ccc1a8818af858d8e63b/transformers-4.57.5.tar.gz", hash = "sha256:d631faea6bd32fc51962e482744afeaa70170c70e5e991cf8e355d7275631524", size = 10138171, upload-time = "2026-01-13T13:28:24.19Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/d3/c16c3b3cf7655a67db1144da94b021c200ac1303f82428f2beef6c2e72bb/transformers-4.57.1-py3-none-any.whl", hash = "sha256:b10d05da8fa67dc41644dbbf9bc45a44cb86ae33da6f9295f5fbf5b7890bd267", size = 11990925, upload-time = "2025-10-14T15:39:23.085Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/de/4f95d22d9764659d2bd35065f383f3fe099699a9e6e89fa4728dbcd7244a/transformers-4.57.5-py3-none-any.whl", hash = "sha256:5a1e0deb989cd0b8f141b6d8c9b7c956fc029cd288d68844f57dc0acbaf2fe39", size = 11993481, upload-time = "2026-01-13T13:28:16.542Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why was this change made?

When starting up, always check to see if there are migrations to run.

Also included here are some adjustments to the setup/teardown of the milvus database. It looks like some recent upstream changes in pymilvus (or its dependencies) exposed a race condition we had in how the database was deleted out from underneath the running fastapi test app.
