### PR TITLE
Bump version to match the release version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-api"
-version = "0.15.0"
+version = "0.16.0"
 description = "Blue Core API for managing BIBFRAME RDF data and workflows"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -81,7 +81,7 @@ wheels = [
 
 [[package]]
 name = "bluecore-api"
-version = "0.15.0"
+version = "0.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "bluecore-models" },


### PR DESCRIPTION
## Why was this change made?
Previous (v0.15.0) release did not include version upgrade in the pyproject.py (still 0.14.0), resulting in drift.
Sync version to 0.16.0

## How was this change tested?
N/A


## Which documentation and/or configurations were updated?
N/A



