### PR TITLE
Use postgres instead of localhost for sqlalchemy.url

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -63,7 +63,7 @@ version_path_separator = os
 # are written from script.py.mako
 # output_encoding = utf-8
 
-sqlalchemy.url = postgresql+psycopg2://airflow:airflow@localhost/bluecore
+sqlalchemy.url = postgresql+psycopg2://airflow:airflow@postgres/bluecore
 
 
 [post_write_hooks]


### PR DESCRIPTION
## Why was this change made?
When spinning up the postgres stack in docker, bc_api must locate the postgres database at the postgres endpoint, not localhost.


## How was this change tested?
Along with the [change made for bluecore-stack](https://github.com/blue-core-lod/bluecore-stack/pull/3) to initialize the database, I spun up the stack using docker desktop.


## Which documentation and/or configurations were updated?
- Update the compose postgres service to run the init multiple db script.
- Update the alembic config to point to the postgres endpoint. If local development requires that the database migration happen on localhost, then the developer should temporarily change this configuration to `sqlalchemy.url = postgresql+psycopg2://airflow:airflow@localhost/bluecore`



