### PR TITLE
Simplify sample JSON-LD data

### DIFF
--- a/sample/batch-small.jsonld
+++ b/sample/batch-small.jsonld
@@ -1,1551 +1,424 @@
 [
   {
-    "@id": "http://id.loc.gov/authorities/genreForms/gf2014026339",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/GenreForm"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "Fiction"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bflc/marcKey": [
-      {
-        "@value": "155  $aFiction"
-      }
-    ]
-  },
-  {
-    "@id": "_:b61iddOtlocdOtgovresourcesinstances24042045",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Extent"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "409 pages"
-      }
-    ]
-  },
-  {
-    "@id": "http://id.loc.gov/vocabulary/countries/fr",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Place"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "France"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/code": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#string",
-        "@value": "fr"
-      }
-    ]
-  },
-  {
-    "@id": "_:b268iddOtlocdOtgovresourcesworks24042045",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/AdminMetadata"
-    ],
-    "http://id.loc.gov/ontologies/bibframe/status": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/mstatus/n"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/date": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#date",
-        "@value": "2024-07-04"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/agent": [
-      {
-        "@id": "_:b278iddOtlocdOtgovresourcesworks24042045"
-      }
-    ]
-  },
-  {
-    "@id": "_:b10iddOtlocdOtgovresourcesinstances24042045",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/ProvisionActivity",
-      "http://id.loc.gov/ontologies/bibframe/Publication"
-    ],
-    "http://id.loc.gov/ontologies/bibframe/date": [
-      {
-        "@type": "http://id.loc.gov/datatypes/edtf",
-        "@value": "2024"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/place": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/countries/fr"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bflc/simplePlace": [
-      {
-        "@value": "Paris"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bflc/simpleAgent": [
-      {
-        "@value": "Albin Michel"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bflc/simpleDate": [
-      {
-        "@value": "[2024]"
-      }
-    ]
-  },
-  {
-    "@id": "_:b115iddOtlocdOtgovresourcesinstances24042045",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/AdminMetadata"
-    ],
-    "http://id.loc.gov/ontologies/bibframe/status": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/mstatus/c"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/agent": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/organizations/dlcmrc"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/generationProcess": [
-      {
-        "@id": "https://github.com/lcnetdev/marc2bibframe2/releases/tag/v2.9.0-dev"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/date": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
-        "@value": "2025-03-13T01:59:54.73343-04:00"
-      }
-    ]
-  },
-  {
-    "@id": "http://id.loc.gov/vocabulary/mstatus/uba",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Status"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "used by assigner"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/code": [
-      {
-        "@value": "uba"
-      }
-    ]
-  },
-  {
-    "@id": "_:b95iddOtlocdOtgovresourcesinstances24042045",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/AdminMetadata"
-    ],
-    "http://id.loc.gov/ontologies/bibframe/status": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/mstatus/c"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/date": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
-        "@value": "2025-03-12T08:27:48"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/descriptionModifier": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/organizations/dlc"
-      }
-    ]
-  },
-  {
-    "@id": "http://id.loc.gov/vocabulary/relators/aut",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Role"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "author"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/code": [
-      {
-        "@value": "aut"
-      }
-    ]
-  },
-  {
-    "@id": "_:b29iddOtlocdOtgovresourcesinstances24042045",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Lccn"
-    ],
-    "http://www.w3.org/1999/02/22-rdf-syntax-ns#value": [
-      {
-        "@value": "  2024384167"
-      }
-    ]
-  },
-  {
-    "@id": "_:b339iddOtlocdOtgovresourcesworks24042045",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Local"
-    ],
-    "http://www.w3.org/1999/02/22-rdf-syntax-ns#value": [
-      {
-        "@value": "24042045"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/assigner": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/organizations/dlc"
-      }
-    ]
-  },
-  {
-    "@id": "_:b152iddOtlocdOtgovresourcesinstances24042045",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Local"
-    ],
-    "http://www.w3.org/1999/02/22-rdf-syntax-ns#value": [
-      {
-        "@value": "24042045"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/assigner": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/organizations/dlc"
-      }
-    ]
-  },
-  {
+    "@context": {
+      "@vocab": "http://id.loc.gov/ontologies/bibframe/",
+      "bflc": "http://id.loc.gov/ontologies/bflc/",
+      "mads": "http://www.loc.gov/mads/rdf/v1#",
+      "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
+    },
     "@id": "http://id.loc.gov/resources/works/24042045",
     "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Work",
-      "http://id.loc.gov/ontologies/bibframe/Text",
-      "http://id.loc.gov/ontologies/bibframe/Monograph"
+      "Work",
+      "Text",
+      "Monograph"
     ],
-    "http://id.loc.gov/ontologies/bflc/aap": [
+    "bflc:aap": "Becker, Emma, 1988-. Le mal joli",
+    "bflc:aap-normalized": "beckeremma1988lemaljoli",
+    "adminMetadata": [
       {
-        "@value": "Becker, Emma, 1988-. Le mal joli"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bflc/aap-normalized": [
-      {
-        "@value": "beckeremma1988lemaljoli"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/language": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/languages/fre"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/genreForm": [
-      {
-        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026339"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/classification": [
-      {
-        "@id": "_:b216iddOtlocdOtgovresourcesworks24042045"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/contribution": [
-      {
-        "@id": "_:b238iddOtlocdOtgovresourcesworks24042045"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/title": [
-      {
-        "@id": "_:b254iddOtlocdOtgovresourcesworks24042045"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/content": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/contentTypes/txt"
-      }
-    ],
-    "http://purl.org/dc/terms/isPartOf": [
-      {
-        "@id": "http://id.loc.gov/resources/works"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/hasInstance": [
-      {
-        "@id": "http://id.loc.gov/resources/instances/24042045"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/adminMetadata": [
-      {
-        "@id": "_:b268iddOtlocdOtgovresourcesworks24042045"
+        "@type": "AdminMetadata",
+        "agent": {
+          "@type": "Agent",
+          "code": "Fr-PaAMA"
+        },
+        "date": {
+          "@type": "http://www.w3.org/2001/XMLSchema#date",
+          "@value": "2024-07-04"
+        },
+        "status": {
+          "@id": "http://id.loc.gov/vocabulary/mstatus/n"
+        }
       },
       {
-        "@id": "_:b282iddOtlocdOtgovresourcesworks24042045"
+        "@type": "AdminMetadata",
+        "date": {
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
+          "@value": "2025-03-12T08:27:48"
+        },
+        "descriptionModifier": {
+          "@id": "http://id.loc.gov/vocabulary/organizations/dlc"
+        },
+        "status": {
+          "@id": "http://id.loc.gov/vocabulary/mstatus/c"
+        }
       },
       {
-        "@id": "_:b302iddOtlocdOtgovresourcesworks24042045"
+        "@type": "AdminMetadata",
+        "agent": {
+          "@id": "http://id.loc.gov/vocabulary/organizations/dlcmrc"
+        },
+        "date": {
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
+          "@value": "2025-03-13T01:59:54.733430-04:00"
+        },
+        "generationProcess": {
+          "@id": "https://github.com/lcnetdev/marc2bibframe2/releases/tag/v2.9.0-dev"
+        },
+        "status": {
+          "@id": "http://id.loc.gov/vocabulary/mstatus/c"
+        }
       },
       {
-        "@id": "_:b324iddOtlocdOtgovresourcesworks24042045"
+        "@type": "AdminMetadata",
+        "bflc:encodingLevel": {
+          "@id": "http://id.loc.gov/vocabulary/menclvl/f"
+        },
+        "descriptionAuthentication": {
+          "@id": "http://id.loc.gov/vocabulary/marcauthen/lccopycat"
+        },
+        "descriptionConventions": [
+          {
+            "@id": "http://id.loc.gov/vocabulary/descriptionConventions/isbd"
+          },
+          {
+            "@id": "http://id.loc.gov/vocabulary/descriptionConventions/rda"
+          }
+        ],
+        "descriptionLanguage": {
+          "@id": "http://id.loc.gov/vocabulary/languages/eng"
+        },
+        "descriptionLevel": {
+          "@id": "http://id.loc.gov/ontologies/bibframe-2-4-0/"
+        },
+        "identifiedBy": {
+          "@type": "Local",
+          "assigner": {
+            "@id": "http://id.loc.gov/vocabulary/organizations/dlc"
+          },
+          "http://www.w3.org/1999/02/22-rdf-syntax-ns#value": "24042045"
+        },
+        "note": {
+          "@type": [
+            "Note",
+            "http://id.loc.gov/vocabulary/mnotetype/internal"
+          ],
+          "rdfs:label": "040  $aFr-PaAMA$beng$erda$cFr-PaAMA$dDLC"
+        }
       }
-    ]
-  },
-  {
-    "@id": "_:b39iddOtlocdOtgovresourcesinstances24042045",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Local"
     ],
-    "http://www.w3.org/1999/02/22-rdf-syntax-ns#value": [
-      {
-        "@value": "AAL08388212-0001"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/assigner": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/organizations/frpaama"
-      }
-    ]
-  },
-  {
-    "@id": "_:b282iddOtlocdOtgovresourcesworks24042045",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/AdminMetadata"
-    ],
-    "http://id.loc.gov/ontologies/bibframe/status": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/mstatus/c"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/date": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
-        "@value": "2025-03-12T08:27:48"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/descriptionModifier": [
-      {
+    "classification": {
+      "@type": "ClassificationLcc",
+      "assigner": {
         "@id": "http://id.loc.gov/vocabulary/organizations/dlc"
-      }
-    ]
-  },
-  {
-    "@id": "http://id.loc.gov/vocabulary/descriptionConventions/rda",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/DescriptionConventions",
-      "http://id.loc.gov/ontologies/bibframe/DescriptionConventions"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Resource description and access"
       },
-      {
-        "@value": "Resource description and access"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/code": [
-      {
-        "@value": "rda"
-      },
-      {
-        "@value": "rda"
-      }
-    ]
-  },
-  {
-    "@id": "http://id.loc.gov/vocabulary/organizations/dlc",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Organization",
-      "http://id.loc.gov/ontologies/bibframe/Organization",
-      "http://id.loc.gov/ontologies/bibframe/Organization",
-      "http://id.loc.gov/ontologies/bibframe/Organization",
-      "http://id.loc.gov/ontologies/bibframe/Organization"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "United States, Library of Congress"
-      },
-      {
-        "@value": "United States, Library of Congress"
-      },
-      {
-        "@value": "United States, Library of Congress"
-      },
-      {
-        "@value": "United States, Library of Congress"
-      },
-      {
-        "@value": "United States, Library of Congress"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/code": [
-      {
-        "@type": "http://id.loc.gov/datatypes/orgs/code",
-        "@value": "DLC"
-      },
-      {
-        "@type": "http://id.loc.gov/datatypes/orgs/normalized",
-        "@value": "dlc"
-      },
-      {
-        "@type": "http://id.loc.gov/datatypes/orgs/iso15511",
-        "@value": "US-dlc"
-      },
-      {
-        "@type": "http://id.loc.gov/datatypes/orgs/code",
-        "@value": "DLC"
-      },
-      {
-        "@type": "http://id.loc.gov/datatypes/orgs/normalized",
-        "@value": "dlc"
-      },
-      {
-        "@type": "http://id.loc.gov/datatypes/orgs/iso15511",
-        "@value": "US-dlc"
-      },
-      {
-        "@type": "http://id.loc.gov/datatypes/orgs/code",
-        "@value": "DLC"
-      },
-      {
-        "@type": "http://id.loc.gov/datatypes/orgs/normalized",
-        "@value": "dlc"
-      },
-      {
-        "@type": "http://id.loc.gov/datatypes/orgs/iso15511",
-        "@value": "US-dlc"
-      },
-      {
-        "@type": "http://id.loc.gov/datatypes/orgs/code",
-        "@value": "DLC"
-      },
-      {
-        "@type": "http://id.loc.gov/datatypes/orgs/normalized",
-        "@value": "dlc"
-      },
-      {
-        "@type": "http://id.loc.gov/datatypes/orgs/iso15511",
-        "@value": "US-dlc"
-      },
-      {
-        "@type": "http://id.loc.gov/datatypes/orgs/code",
-        "@value": "DLC"
-      },
-      {
-        "@type": "http://id.loc.gov/datatypes/orgs/normalized",
-        "@value": "dlc"
-      },
-      {
-        "@type": "http://id.loc.gov/datatypes/orgs/iso15511",
-        "@value": "US-dlc"
-      }
-    ]
-  },
-  {
-    "@id": "_:b324iddOtlocdOtgovresourcesworks24042045",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/AdminMetadata"
-    ],
-    "http://id.loc.gov/ontologies/bibframe/descriptionLevel": [
-      {
-        "@id": "http://id.loc.gov/ontologies/bibframe-2-4-0/"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bflc/encodingLevel": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/menclvl/f"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/descriptionConventions": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/descriptionConventions/isbd"
-      },
-      {
-        "@id": "http://id.loc.gov/vocabulary/descriptionConventions/rda"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/identifiedBy": [
-      {
-        "@id": "_:b339iddOtlocdOtgovresourcesworks24042045"
-      }
-    ],
-    "http://id.loc.gov/ontologies/lclocal/d906": [
-      {
-        "@value": "=906     $a 7 $b cbc $c copycat $d 3 $e ncip $f 20 $g y-gencatlg"
-      }
-    ],
-    "http://id.loc.gov/ontologies/lclocal/d925": [
-      {
-        "@value": "=925  0  $a acquire $b 1 shelf copy $x policy default"
-      }
-    ],
-    "http://id.loc.gov/ontologies/lclocal/d955": [
-      {
-        "@value": "=955     $a am00 2025-02-25 item has been shipped $a bd25 2025-03-12 item received; to PresSrvs"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/descriptionLanguage": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/languages/eng"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/note": [
-      {
-        "@id": "_:b371iddOtlocdOtgovresourcesworks24042045"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/descriptionAuthentication": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/marcauthen/lccopycat"
-      }
-    ],
-    "http://id.loc.gov/ontologies/lclocal/d985": [
-      {
-        "@value": "=985     $a shelf ready $e AM-FY25"
-      }
-    ]
-  },
-  {
-    "@id": "_:b33iddOtlocdOtgovresourcesinstances24042045",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Isbn"
-    ],
-    "http://www.w3.org/1999/02/22-rdf-syntax-ns#value": [
-      {
-        "@value": "9782226489784"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/qualifier": [
-      {
-        "@value": "paperback"
-      }
-    ]
-  },
-  {
-    "@id": "http://id.loc.gov/vocabulary/marcauthen/lccopycat",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/DescriptionAuthentication",
-      "http://id.loc.gov/ontologies/bibframe/DescriptionAuthentication"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "LC Copy Cataloging"
-      },
-      {
-        "@value": "LC Copy Cataloging"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/code": [
-      {
-        "@value": "lccopycat"
-      },
-      {
-        "@value": "lccopycat"
-      }
-    ]
-  },
-  {
-    "@id": "_:b137iddOtlocdOtgovresourcesinstances24042045",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/AdminMetadata"
-    ],
-    "http://id.loc.gov/ontologies/bibframe/descriptionLevel": [
-      {
-        "@id": "http://id.loc.gov/ontologies/bibframe-2-4-0/"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bflc/encodingLevel": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/menclvl/f"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/descriptionConventions": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/descriptionConventions/isbd"
-      },
-      {
-        "@id": "http://id.loc.gov/vocabulary/descriptionConventions/rda"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/identifiedBy": [
-      {
-        "@id": "_:b152iddOtlocdOtgovresourcesinstances24042045"
-      }
-    ],
-    "http://id.loc.gov/ontologies/lclocal/d906": [
-      {
-        "@value": "=906     $a 7 $b cbc $c copycat $d 3 $e ncip $f 20 $g y-gencatlg"
-      }
-    ],
-    "http://id.loc.gov/ontologies/lclocal/d925": [
-      {
-        "@value": "=925  0  $a acquire $b 1 shelf copy $x policy default"
-      }
-    ],
-    "http://id.loc.gov/ontologies/lclocal/d955": [
-      {
-        "@value": "=955     $a am00 2025-02-25 item has been shipped $a bd25 2025-03-12 item received; to PresSrvs"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/descriptionLanguage": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/languages/eng"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/note": [
-      {
-        "@id": "_:b184iddOtlocdOtgovresourcesinstances24042045"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/descriptionAuthentication": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/marcauthen/lccopycat"
-      }
-    ],
-    "http://id.loc.gov/ontologies/lclocal/d985": [
-      {
-        "@value": "=985     $a shelf ready $e AM-FY25"
-      }
-    ]
-  },
-  {
-    "@id": "http://id.loc.gov/vocabulary/menclvl/f",
-    "@type": [
-      "http://id.loc.gov/ontologies/bflc/EncodingLevel",
-      "http://id.loc.gov/ontologies/bflc/EncodingLevel"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "full"
-      },
-      {
-        "@value": "full"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/code": [
-      {
-        "@value": "f"
-      },
-      {
-        "@value": "f"
-      }
-    ]
-  },
-  {
-    "@id": "http://id.loc.gov/vocabulary/organizations/frpaama",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Organization"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "AMALIVRE"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/code": [
-      {
-        "@type": "http://id.loc.gov/datatypes/orgs/code",
-        "@value": "FR-PaAMA"
-      },
-      {
-        "@type": "http://id.loc.gov/datatypes/orgs/normalized",
-        "@value": "frpaama"
-      }
-    ]
-  },
-  {
-    "@id": "http://id.loc.gov/vocabulary/descriptionConventions/isbd",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/DescriptionConventions",
-      "http://id.loc.gov/ontologies/bibframe/DescriptionConventions"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "ISBD: International standard bibliographic description"
-      },
-      {
-        "@value": "ISBD: International standard bibliographic description"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/code": [
-      {
-        "@value": "isbd"
-      },
-      {
-        "@value": "isbd"
-      }
-    ]
-  },
-  {
-    "@id": "http://id.loc.gov/vocabulary/mediaTypes/n",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Media"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "unmediated"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/code": [
-      {
-        "@value": "n"
-      }
-    ]
-  },
-  {
-    "@id": "http://id.loc.gov/vocabulary/organizations/dlcmrc",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Agent",
-      "http://id.loc.gov/ontologies/bibframe/Organization",
-      "http://id.loc.gov/ontologies/bibframe/Agent",
-      "http://id.loc.gov/ontologies/bibframe/Organization"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "United States, Library of Congress, Network Development and MARC Standards Office"
-      },
-      {
-        "@value": "United States, Library of Congress, Network Development and MARC Standards Office"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/code": [
-      {
-        "@type": "http://id.loc.gov/datatypes/orgs/code",
-        "@value": "DLC-MRC"
-      },
-      {
-        "@type": "http://id.loc.gov/datatypes/orgs/normalized",
-        "@value": "dlcmrc"
-      },
-      {
-        "@type": "http://id.loc.gov/datatypes/orgs/iso15511",
-        "@value": "US-dlcmrc"
-      },
-      {
-        "@type": "http://id.loc.gov/datatypes/orgs/code",
-        "@value": "DLC-MRC"
-      },
-      {
-        "@type": "http://id.loc.gov/datatypes/orgs/normalized",
-        "@value": "dlcmrc"
-      },
-      {
-        "@type": "http://id.loc.gov/datatypes/orgs/iso15511",
-        "@value": "US-dlcmrc"
-      }
-    ]
-  },
-  {
-    "@id": "http://id.loc.gov/vocabulary/languages/eng",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Language",
-      "http://id.loc.gov/ontologies/bibframe/Language"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "English"
-      },
-      {
-        "@language": "en",
-        "@value": "English"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/code": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#string",
-        "@value": "eng"
-      },
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#string",
-        "@value": "eng"
-      }
-    ]
-  },
-  {
-    "@id": "_:b238iddOtlocdOtgovresourcesworks24042045",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Contribution",
-      "http://id.loc.gov/ontologies/bibframe/PrimaryContribution"
-    ],
-    "http://id.loc.gov/ontologies/bibframe/agent": [
-      {
-        "@id": "http://id.loc.gov/rwo/agents/no2012149645"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/role": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/relators/aut"
-      }
-    ]
-  },
-  {
-    "@id": "http://id.loc.gov/rwo/agents/no2012149645",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Agent",
-      "http://id.loc.gov/ontologies/bibframe/Person"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "Becker, Emma, 1988-"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bflc/marcKey": [
-      {
-        "@value": "1001 $aBecker, Emma,$d1988-"
-      }
-    ]
-  },
-  {
-    "@id": "http://id.loc.gov/vocabulary/carriers/nc",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Carrier"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "volume"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/code": [
-      {
-        "@value": "nc"
-      }
-    ]
-  },
-  {
-    "@id": "_:b254iddOtlocdOtgovresourcesworks24042045",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Title"
-    ],
-    "http://id.loc.gov/ontologies/bibframe/mainTitle": [
-      {
-        "@value": "Le mal joli"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bflc/nonSortNum": [
-      {
-        "@value": "3"
-      }
-    ]
-  },
-  {
-    "@id": "_:b278iddOtlocdOtgovresourcesworks24042045",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Agent"
-    ],
-    "http://id.loc.gov/ontologies/bibframe/code": [
-      {
-        "@value": "Fr-PaAMA"
-      }
-    ]
-  },
-  {
-    "@id": "_:b53iddOtlocdOtgovresourcesinstances24042045",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Title"
-    ],
-    "http://id.loc.gov/ontologies/bibframe/mainTitle": [
-      {
-        "@value": "Le mal joli"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/subtitle": [
-      {
-        "@value": "roman"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bflc/nonSortNum": [
-      {
-        "@value": "3"
-      }
-    ]
-  },
-  {
-    "@id": "_:b302iddOtlocdOtgovresourcesworks24042045",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/AdminMetadata"
-    ],
-    "http://id.loc.gov/ontologies/bibframe/status": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/mstatus/c"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/agent": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/organizations/dlcmrc"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/generationProcess": [
-      {
-        "@id": "https://github.com/lcnetdev/marc2bibframe2/releases/tag/v2.9.0-dev"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/date": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
-        "@value": "2025-03-13T01:59:54.73343-04:00"
-      }
-    ]
-  },
-  {
-    "@id": "_:b81iddOtlocdOtgovresourcesinstances24042045",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/AdminMetadata"
-    ],
-    "http://id.loc.gov/ontologies/bibframe/status": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/mstatus/n"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/date": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#date",
-        "@value": "2024-07-04"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/agent": [
-      {
-        "@id": "_:b91iddOtlocdOtgovresourcesinstances24042045"
-      }
-    ]
-  },
-  {
-    "@id": "_:b216iddOtlocdOtgovresourcesworks24042045",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/ClassificationLcc"
-    ],
-    "http://id.loc.gov/ontologies/bibframe/classificationPortion": [
-      {
-        "@value": "PQ2702.E298"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/itemPortion": [
-      {
-        "@value": "M36 2024"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/assigner": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/organizations/dlc"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/status": [
-      {
+      "classificationPortion": "PQ2702.E298",
+      "itemPortion": "M36 2024",
+      "status": {
         "@id": "http://id.loc.gov/vocabulary/mstatus/uba"
       }
-    ]
-  },
-  {
-    "@id": "http://id.loc.gov/vocabulary/issuance/mono",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Issuance"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "single unit"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/code": [
-      {
-        "@value": "mono"
-      }
-    ]
-  },
-  {
-    "@id": "http://id.loc.gov/vocabulary/mstatus/c",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Status",
-      "http://id.loc.gov/ontologies/bibframe/Status",
-      "http://id.loc.gov/ontologies/bibframe/Status",
-      "http://id.loc.gov/ontologies/bibframe/Status"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "changed"
+    },
+    "content": {
+      "@id": "http://id.loc.gov/vocabulary/contentTypes/txt"
+    },
+    "contribution": {
+      "@type": [
+        "Contribution",
+        "PrimaryContribution"
+      ],
+      "agent": {
+        "@id": "http://id.loc.gov/rwo/agents/no2012149645"
       },
-      {
-        "@value": "changed"
-      },
-      {
-        "@value": "changed"
-      },
-      {
-        "@value": "changed"
+      "role": {
+        "@id": "http://id.loc.gov/vocabulary/relators/aut"
       }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/code": [
-      {
-        "@value": "c"
-      },
-      {
-        "@value": "c"
-      },
-      {
-        "@value": "c"
-      },
-      {
-        "@value": "c"
-      }
-    ]
-  },
-  {
-    "@id": "http://id.loc.gov/resources/instances/24042045",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Instance"
-    ],
-    "http://id.loc.gov/ontologies/bibframe/issuance": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/issuance/mono"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/provisionActivity": [
-      {
-        "@id": "_:b10iddOtlocdOtgovresourcesinstances24042045"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/publicationStatement": [
-      {
-        "@value": "Paris: Albin Michel, [2024]"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/identifiedBy": [
-      {
-        "@id": "_:b29iddOtlocdOtgovresourcesinstances24042045"
-      },
-      {
-        "@id": "_:b33iddOtlocdOtgovresourcesinstances24042045"
-      },
-      {
-        "@id": "_:b39iddOtlocdOtgovresourcesinstances24042045"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/responsibilityStatement": [
-      {
-        "@value": "Emma Becker"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/title": [
-      {
-        "@id": "_:b53iddOtlocdOtgovresourcesinstances24042045"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/extent": [
-      {
-        "@id": "_:b61iddOtlocdOtgovresourcesinstances24042045"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/dimensions": [
-      {
-        "@value": "21 cm"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/media": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/mediaTypes/n"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/carrier": [
-      {
+    },
+    "genreForm": {
+      "@id": "http://id.loc.gov/authorities/genreForms/gf2014026339"
+    },
+    "hasInstance": {
+      "@id": "http://id.loc.gov/resources/instances/24042045",
+      "@type": "Instance",
+      "adminMetadata": [
+        {
+          "@type": "AdminMetadata",
+          "agent": {
+            "@type": "Agent",
+            "code": "Fr-PaAMA"
+          },
+          "date": {
+            "@type": "http://www.w3.org/2001/XMLSchema#date",
+            "@value": "2024-07-04"
+          },
+          "status": {
+            "@id": "http://id.loc.gov/vocabulary/mstatus/n"
+          }
+        },
+        {
+          "@type": "AdminMetadata",
+          "date": {
+            "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
+            "@value": "2025-03-12T08:27:48"
+          },
+          "descriptionModifier": {
+            "@id": "http://id.loc.gov/vocabulary/organizations/dlc"
+          },
+          "status": {
+            "@id": "http://id.loc.gov/vocabulary/mstatus/c"
+          }
+        },
+        {
+          "@type": "AdminMetadata",
+          "agent": {
+            "@id": "http://id.loc.gov/vocabulary/organizations/dlcmrc"
+          },
+          "date": {
+            "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
+            "@value": "2025-03-13T01:59:54.733430-04:00"
+          },
+          "generationProcess": {
+            "@id": "https://github.com/lcnetdev/marc2bibframe2/releases/tag/v2.9.0-dev"
+          },
+          "status": {
+            "@id": "http://id.loc.gov/vocabulary/mstatus/c"
+          }
+        },
+        {
+          "@type": "AdminMetadata",
+          "bflc:encodingLevel": {
+            "@id": "http://id.loc.gov/vocabulary/menclvl/f"
+          },
+          "descriptionAuthentication": {
+            "@id": "http://id.loc.gov/vocabulary/marcauthen/lccopycat"
+          },
+          "descriptionConventions": [
+            {
+              "@id": "http://id.loc.gov/vocabulary/descriptionConventions/isbd"
+            },
+            {
+              "@id": "http://id.loc.gov/vocabulary/descriptionConventions/rda"
+            }
+          ],
+          "descriptionLanguage": {
+            "@id": "http://id.loc.gov/vocabulary/languages/eng"
+          },
+          "descriptionLevel": {
+            "@id": "http://id.loc.gov/ontologies/bibframe-2-4-0/"
+          },
+          "identifiedBy": {
+            "@type": "Local",
+            "assigner": {
+              "@id": "http://id.loc.gov/vocabulary/organizations/dlc"
+            },
+            "http://www.w3.org/1999/02/22-rdf-syntax-ns#value": "24042045"
+          },
+          "note": {
+            "@type": [
+              "Note",
+              "http://id.loc.gov/vocabulary/mnotetype/internal"
+            ],
+            "rdfs:label": "040  $aFr-PaAMA$beng$erda$cFr-PaAMA$dDLC"
+          }
+        }
+      ],
+      "carrier": {
         "@id": "http://id.loc.gov/vocabulary/carriers/nc"
-      }
-    ],
-    "http://purl.org/dc/terms/isPartOf": [
-      {
-        "@id": "http://id.loc.gov/resources/instances"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/instanceOf": [
-      {
+      },
+      "dimensions": "21 cm",
+      "extent": {
+        "@type": "Extent",
+        "rdfs:label": "409 pages"
+      },
+      "identifiedBy": [
+        {
+          "@type": "Lccn",
+          "http://www.w3.org/1999/02/22-rdf-syntax-ns#value": "  2024384167"
+        },
+        {
+          "@type": "Isbn",
+          "qualifier": "paperback",
+          "http://www.w3.org/1999/02/22-rdf-syntax-ns#value": "9782226489784"
+        },
+        {
+          "@type": "Local",
+          "assigner": {
+            "@id": "http://id.loc.gov/vocabulary/organizations/frpaama"
+          },
+          "http://www.w3.org/1999/02/22-rdf-syntax-ns#value": "AAL08388212-0001"
+        }
+      ],
+      "instanceOf": {
         "@id": "http://id.loc.gov/resources/works/24042045"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/adminMetadata": [
-      {
-        "@id": "_:b81iddOtlocdOtgovresourcesinstances24042045"
       },
-      {
-        "@id": "_:b95iddOtlocdOtgovresourcesinstances24042045"
+      "issuance": {
+        "@id": "http://id.loc.gov/vocabulary/issuance/mono"
       },
-      {
-        "@id": "_:b115iddOtlocdOtgovresourcesinstances24042045"
+      "media": {
+        "@id": "http://id.loc.gov/vocabulary/mediaTypes/n"
       },
-      {
-        "@id": "_:b137iddOtlocdOtgovresourcesinstances24042045"
-      }
-    ]
-  },
-  {
-    "@id": "http://id.loc.gov/vocabulary/contentTypes/txt",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Content"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "text"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/code": [
-      {
-        "@value": "txt"
-      }
-    ]
-  },
-  {
-    "@id": "_:b371iddOtlocdOtgovresourcesworks24042045",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Note",
-      "http://id.loc.gov/vocabulary/mnotetype/internal"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "040  $aFr-PaAMA$beng$erda$cFr-PaAMA$dDLC"
-      }
-    ]
-  },
-  {
-    "@id": "_:b91iddOtlocdOtgovresourcesinstances24042045",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Agent"
-    ],
-    "http://id.loc.gov/ontologies/bibframe/code": [
-      {
-        "@value": "Fr-PaAMA"
-      }
-    ]
-  },
-  {
-    "@id": "_:b184iddOtlocdOtgovresourcesinstances24042045",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Note",
-      "http://id.loc.gov/vocabulary/mnotetype/internal"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "040  $aFr-PaAMA$beng$erda$cFr-PaAMA$dDLC"
-      }
-    ]
-  },
-  {
-    "@id": "http://id.loc.gov/vocabulary/mstatus/n",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Status",
-      "http://id.loc.gov/ontologies/bibframe/Status"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "new"
+      "provisionActivity": {
+        "@type": [
+          "ProvisionActivity",
+          "Publication"
+        ],
+        "bflc:simpleAgent": "Albin Michel",
+        "bflc:simpleDate": "[2024]",
+        "bflc:simplePlace": "Paris",
+        "date": {
+          "@type": "http://id.loc.gov/datatypes/edtf",
+          "@value": "2024"
+        },
+        "place": {
+          "@id": "http://id.loc.gov/vocabulary/countries/fr"
+        }
       },
-      {
-        "@value": "new"
+      "publicationStatement": "Paris: Albin Michel, [2024]",
+      "responsibilityStatement": "Emma Becker",
+      "title": {
+        "@type": "Title",
+        "bflc:nonSortNum": "3",
+        "mainTitle": "Le mal joli",
+        "subtitle": "roman"
       }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/code": [
-      {
-        "@value": "n"
-      },
-      {
-        "@value": "n"
-      }
-    ]
+    },
+    "language": {
+      "@id": "http://id.loc.gov/vocabulary/languages/fre"
+    },
+    "title": {
+      "@type": "Title",
+      "bflc:nonSortNum": "3",
+      "mainTitle": "Le mal joli"
+    }
   },
   {
-    "@id": "http://id.loc.gov/vocabulary/languages/fre",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Language"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "French"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/code": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#string",
-        "@value": "fre"
-      }
-    ]
-  },
-  {
-    "@id": "_:b51iddOtlocdOtgovresourcesinstances24113259",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Title"
-    ],
-    "http://id.loc.gov/ontologies/bibframe/mainTitle": [
-      {
-        "@value": "In the Senate of the United States. January 18, 1892. -- Referred to the Committee on Coast Defenses and ordered to be printed. Mr. Allen presented the following memorial of the Port Townsend Chamber of Commerce on the subject of coast defenses .."
-      }
-    ]
-  },
-  {
-    "@id": "_:b411iddOtlocdOtgovresourcesworks24113259",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Contribution"
-    ],
-    "http://id.loc.gov/ontologies/bibframe/agent": [
-      {
-        "@id": "_:b413iddOtlocdOtgovresourcesworks24113259"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/role": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/relators/ctb"
-      }
-    ]
-  },
-  {
-    "@id": "_:b10iddOtlocdOtgovresourcesinstances24113259",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/ProvisionActivity",
-      "http://id.loc.gov/ontologies/bibframe/Publication"
-    ],
-    "http://id.loc.gov/ontologies/bibframe/date": [
-      {
-        "@type": "http://id.loc.gov/datatypes/edtf",
-        "@value": "1892"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/place": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/countries/dcu"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bflc/simplePlace": [
-      {
-        "@value": "[Washington, D.C.]"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bflc/simpleAgent": [
-      {
-        "@value": "U.S. Government Printing Office"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bflc/simpleDate": [
-      {
-        "@value": "1892"
-      }
-    ]
-  },
-  {
-    "@id": "_:b466iddOtlocdOtgovresourcesworks24113259",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Series",
-      "http://id.loc.gov/ontologies/bflc/Uncontrolled"
-    ],
-    "http://id.loc.gov/ontologies/bibframe/status": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/mstatus/t"
-      },
-      {
-        "@id": "http://id.loc.gov/vocabulary/mstatus/tr"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/title": [
-      {
-        "@id": "_:b481iddOtlocdOtgovresourcesworks24113259"
-      }
-    ]
-  },
-  {
-    "@id": "http://id.loc.gov/vocabulary/mgovtpubtype/f",
-    "@type": [
-      "http://id.loc.gov/ontologies/bflc/GovernmentPubType"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "federal or national"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/code": [
-      {
-        "@value": "f"
-      }
-    ]
-  },
-  {
-    "@id": "http://id.loc.gov/vocabulary/relators/aut",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Role",
-      "http://id.loc.gov/ontologies/bibframe/Role"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "author"
-      },
-      {
-        "@value": "author"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/code": [
-      {
-        "@value": "aut"
-      },
-      {
-        "@value": "aut"
-      }
-    ]
-  },
-  {
-    "@id": "_:b82iddOtlocdOtgovresourcesinstances24113259",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/AdminMetadata"
-    ],
-    "http://id.loc.gov/ontologies/bibframe/status": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/mstatus/n"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/date": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#date",
-        "@value": "2025-01-17"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/agent": [
-      {
-        "@id": "_:b92iddOtlocdOtgovresourcesinstances24113259"
-      }
-    ]
-  },
-  {
+    "@context": {
+      "@vocab": "http://id.loc.gov/ontologies/bibframe/",
+      "bflc": "http://id.loc.gov/ontologies/bflc/",
+      "mads": "http://www.loc.gov/mads/rdf/v1#",
+      "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
+    },
     "@id": "http://id.loc.gov/resources/works/24113259",
     "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Work",
-      "http://id.loc.gov/ontologies/bibframe/Text",
-      "http://id.loc.gov/ontologies/bibframe/Monograph"
+      "Work",
+      "Text",
+      "Monograph"
     ],
-    "http://id.loc.gov/ontologies/bflc/aap": [
+    "bflc:aap": "United States Congress. Senate. In the Senate of the United States. January 18, 1892. -- Referred to the Committee on Coast Defenses and ordered to be printed. Mr. Allen presented the following memorial of the Port Townsend Chamber of Commerce on the subject of coast defenses .",
+    "bflc:aap-normalized": "unitedstatescongresssenateinthesenateoftheunitedstatesjanuary181892referredtothecommitteeoncoastdefensesandorderedtobeprintedmrallenpresentedthefollowingmemorialoftheporttownsendchamberofcommerceonthesubjectofcoastdefenses",
+    "bflc:governmentPubType": {
+      "@id": "http://id.loc.gov/vocabulary/mgovtpubtype/f"
+    },
+    "adminMetadata": [
+      {},
+      {},
+      {}
+    ],
+    "classification": [
+      {},
+      {},
+      {}
+    ],
+    "content": {
+      "@id": "http://id.loc.gov/vocabulary/contentTypes/txt"
+    },
+    "contribution": [
+      {},
+      {},
+      {},
+      {},
       {
-        "@value": "United States Congress. Senate. In the Senate of the United States. January 18, 1892. -- Referred to the Committee on Coast Defenses and ordered to be printed. Mr. Allen presented the following memorial of the Port Townsend Chamber of Commerce on the subject of coast defenses ."
+        "@type": "Contribution",
+        "agent": {},
+        "role": {
+          "@id": "http://id.loc.gov/vocabulary/relators/ctb"
+        }
       }
     ],
-    "http://id.loc.gov/ontologies/bflc/aap-normalized": [
+    "genreForm": [
+      {},
+      {},
       {
-        "@value": "unitedstatescongresssenateinthesenateoftheunitedstatesjanuary181892referredtothecommitteeoncoastdefensesandorderedtobeprintedmrallenpresentedthefollowingmemorialoftheporttownsendchamberofcommerceonthesubjectofcoastdefenses"
+        "@id": "http://id.loc.gov/authorities/genreForms/gf2011026362"
       }
     ],
-    "http://id.loc.gov/ontologies/bibframe/language": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/languages/eng"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bflc/governmentPubType": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/mgovtpubtype/f"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/classification": [
-      {
-        "@id": "_:b185iddOtlocdOtgovresourcesworks24113259"
+    "hasInstance": {
+      "@id": "http://id.loc.gov/resources/instances/24113259",
+      "@type": "Instance",
+      "adminMetadata": [
+        {
+          "@type": "AdminMetadata",
+          "agent": {},
+          "date": {
+            "@type": "http://www.w3.org/2001/XMLSchema#date",
+            "@value": "2025-01-17"
+          },
+          "status": {
+            "@id": "http://id.loc.gov/vocabulary/mstatus/n"
+          }
+        },
+        {},
+        {}
+      ],
+      "carrier": {
+        "@id": "http://id.loc.gov/vocabulary/carriers/cr"
       },
-      {
-        "@id": "_:b205iddOtlocdOtgovresourcesworks24113259"
+      "extent": {
+        "@type": "Extent",
+        "rdfs:label": "1 online resource (5 pages)."
       },
-      {
-        "@id": "_:b215iddOtlocdOtgovresourcesworks24113259"
+      "identifiedBy": [
+        {},
+        {},
+        {}
+      ],
+      "instanceOf": {
+        "@id": "http://id.loc.gov/resources/works/24113259"
+      },
+      "issuance": {
+        "@id": "http://id.loc.gov/vocabulary/issuance/mono"
+      },
+      "media": {
+        "@id": "http://id.loc.gov/vocabulary/mediaTypes/c"
+      },
+      "note": {},
+      "provisionActivity": {
+        "@type": [
+          "ProvisionActivity",
+          "Publication"
+        ],
+        "bflc:simpleAgent": "U.S. Government Printing Office",
+        "bflc:simpleDate": "1892",
+        "bflc:simplePlace": "[Washington, D.C.]",
+        "date": {
+          "@type": "http://id.loc.gov/datatypes/edtf",
+          "@value": "1892"
+        },
+        "place": {
+          "@id": "http://id.loc.gov/vocabulary/countries/dcu"
+        }
+      },
+      "publicationStatement": "[Washington, D.C.]: U.S. Government Printing Office, 1892",
+      "title": {
+        "@type": "Title",
+        "mainTitle": "In the Senate of the United States. January 18, 1892. -- Referred to the Committee on Coast Defenses and ordered to be printed. Mr. Allen presented the following memorial of the Port Townsend Chamber of Commerce on the subject of coast defenses .."
       }
+    },
+    "language": {
+      "@id": "http://id.loc.gov/vocabulary/languages/eng"
+    },
+    "relation": [
+      {},
+      {}
     ],
-    "http://id.loc.gov/ontologies/bibframe/contribution": [
-      {
-        "@id": "_:b225iddOtlocdOtgovresourcesworks24113259"
-      },
-      {
-        "@id": "_:b360iddOtlocdOtgovresourcesworks24113259"
-      },
-      {
-        "@id": "_:b375iddOtlocdOtgovresourcesworks24113259"
-      },
-      {
-        "@id": "_:b396iddOtlocdOtgovresourcesworks24113259"
-      },
-      {
-        "@id": "_:b411iddOtlocdOtgovresourcesworks24113259"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/title": [
-      {
-        "@id": "_:b241iddOtlocdOtgovresourcesworks24113259"
-      },
-      {
-        "@id": "_:b245iddOtlocdOtgovresourcesworks24113259"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/content": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/contentTypes/txt"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/subject": [
+    "subject": [
       {
         "@id": "http://id.loc.gov/authorities/subjects/sh85027424"
       },
       {
         "@id": "http://id.loc.gov/authorities/subjects/sh85085159"
       },
-      {
-        "@id": "_:b271iddOtlocdOtgovresourcesworks24113259"
-      },
+      {},
       {
         "@id": "http://id.loc.gov/authorities/subjects/sh85119483"
       },
-      {
-        "@id": "_:b294iddOtlocdOtgovresourcesworks24113259"
-      },
+      {},
       {
         "@id": "http://id.loc.gov/authorities/subjects/sh85108969"
       },
-      {
-        "@id": "_:b317iddOtlocdOtgovresourcesworks24113259"
-      }
+      {}
     ],
-    "http://id.loc.gov/ontologies/bibframe/genreForm": [
-      {
-        "@id": "_:b334iddOtlocdOtgovresourcesworks24113259"
-      },
-      {
-        "@id": "_:b347iddOtlocdOtgovresourcesworks24113259"
-      },
-      {
-        "@id": "http://id.loc.gov/authorities/genreForms/gf2011026362"
-      }
-    ],
-    "http://purl.org/dc/terms/isPartOf": [
-      {
-        "@id": "http://id.loc.gov/resources/works"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/relation": [
-      {
-        "@id": "_:b427iddOtlocdOtgovresourcesworks24113259"
-      },
-      {
-        "@id": "_:b456iddOtlocdOtgovresourcesworks24113259"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/hasInstance": [
-      {
-        "@id": "http://id.loc.gov/resources/instances/24113259"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/adminMetadata": [
-      {
-        "@id": "_:b486iddOtlocdOtgovresourcesworks24113259"
-      },
-      {
-        "@id": "_:b500iddOtlocdOtgovresourcesworks24113259"
-      },
-      {
-        "@id": "_:b522iddOtlocdOtgovresourcesworks24113259"
-      }
-    ]
-  },
-  {
-    "@id": "_:b121iddOtlocdOtgovresourcesinstances24113259",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Local"
-    ],
-    "http://www.w3.org/1999/02/22-rdf-syntax-ns#value": [
-      {
-        "@value": "24113259"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/assigner": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/organizations/dlc"
-      }
-    ]
-  },
-  {
-    "@id": "_:b55iddOtlocdOtgovresourcesinstances24113259",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Extent"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@value": "1 online resource (5 pages)."
-      }
-    ]
-  },
-  {
-    "@id": "http://id.loc.gov/resources/instances/24113259",
-    "@type": [
-      "http://id.loc.gov/ontologies/bibframe/Instance"
-    ],
-    "http://id.loc.gov/ontologies/bibframe/issuance": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/issuance/mono"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/provisionActivity": [
-      {
-        "@id": "_:b10iddOtlocdOtgovresourcesinstances24113259"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/publicationStatement": [
-      {
-        "@value": "[Washington, D.C.]: U.S. Government Printing Office, 1892"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/identifiedBy": [
-      {
-        "@id": "_:b29iddOtlocdOtgovresourcesinstances24113259"
-      },
-      {
-        "@id": "_:b33iddOtlocdOtgovresourcesinstances24113259"
-      },
-      {
-        "@id": "_:b47iddOtlocdOtgovresourcesinstances24113259"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/title": [
-      {
-        "@id": "_:b51iddOtlocdOtgovresourcesinstances24113259"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/extent": [
-      {
-        "@id": "_:b55iddOtlocdOtgovresourcesinstances24113259"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/note": [
-      {
-        "@id": "_:b59iddOtlocdOtgovresourcesinstances24113259"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/media": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/mediaTypes/c"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/carrier": [
-      {
-        "@id": "http://id.loc.gov/vocabulary/carriers/cr"
-      }
-    ],
-    "http://purl.org/dc/terms/isPartOf": [
-      {
-        "@id": "http://id.loc.gov/resources/instances"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/instanceOf": [
-      {
-        "@id": "http://id.loc.gov/resources/works/24113259"
-      }
-    ],
-    "http://id.loc.gov/ontologies/bibframe/adminMetadata": [
-      {
-        "@id": "_:b82iddOtlocdOtgovresourcesinstances24113259"
-      },
-      {
-        "@id": "_:b96iddOtlocdOtgovresourcesinstances24113259"
-      },
-      {
-        "@id": "_:b118iddOtlocdOtgovresourcesinstances24113259"
-      }
+    "title": [
+      {},
+      {}
     ]
   }
 ]


### PR DESCRIPTION
## Why was this change made?

One of the difficulties of working with JSON-LD (and RDF in
general) is that there are many ways of saying the same thing, and some
are easier to read than others.

To make it a bit easier for engineers (who are generally more familiar
with JSON) to work with the sample metadata it is helpful to "frame" it
so it looks like the JSON-LD that the bluecore_api makes available.

The JSON file contains a list of framed Bibframe Works that includes each of their Instances, for example:

```json
{
  "@context": {
    "@vocab": "http://id.loc.gov/ontologies/bibframe/",
    "bflc": "http://id.loc.gov/ontologies/bflc/",
    "mads": "http://www.loc.gov/mads/rdf/v1#",
    "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
  },
  "@id": "http://id.loc.gov/resources/works/24042045",
  "@type": [
    "Work",
    "Text",
    "Monograph"
  ],
  "bflc:aap": "Becker, Emma, 1988-. Le mal joli",
  "bflc:aap-normalized": "beckeremma1988lemaljoli",
  "adminMetadata": [
    {
      "@type": "AdminMetadata",
      "agent": {
        "@type": "Agent",
        "code": "Fr-PaAMA"
      },
      "date": {
        "@type": "http://www.w3.org/2001/XMLSchema#date",
        "@value": "2024-07-04"
      },
      "status": {
        "@id": "http://id.loc.gov/vocabulary/mstatus/n",
        "@type": "Status",
        "code": "n",
        "rdfs:label": "new"
      }
    },
    {
      "@type": "AdminMetadata",
      "date": {
        "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
        "@value": "2025-03-12T08:27:48"
      },
      "descriptionModifier": {
        "@id": "http://id.loc.gov/vocabulary/organizations/dlc",
        "@type": [
          "Organization",
          "Agent",
          "mads:CorporateName"
        ],
        "code": [
          {
            "@type": "http://id.loc.gov/datatypes/orgs/code",
            "@value": "DLC"
          },
          {
            "@type": "http://id.loc.gov/datatypes/orgs/normalized",
            "@value": "dlc"
          },
          {
            "@type": "http://id.loc.gov/datatypes/orgs/iso15511",
            "@value": "US-dlc"
          }
        ],
        "rdfs:label": "United States, Library of Congress"
      },
      "status": {
        "@id": "http://id.loc.gov/vocabulary/mstatus/c",
        "@type": "Status",
        "code": "c",
        "rdfs:label": "changed"
      }
    },
    {
      "@type": "AdminMetadata",
      "agent": {
        "@id": "http://id.loc.gov/vocabulary/organizations/dlcmrc",
        "@type": [
          "Agent",
          "Organization"
        ],
        "code": [
          {
            "@type": "http://id.loc.gov/datatypes/orgs/code",
            "@value": "DLC-MRC"
          },
          {
            "@type": "http://id.loc.gov/datatypes/orgs/normalized",
            "@value": "dlcmrc"
          },
          {
            "@type": "http://id.loc.gov/datatypes/orgs/iso15511",
            "@value": "US-dlcmrc"
          }
        ],
        "rdfs:label": "United States, Library of Congress, Network Development and MARC Standards Office"
      },
      "date": {
        "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
        "@value": "2025-03-13T01:59:54.733430-04:00"
      },
      "generationProcess": {
        "@id": "https://github.com/lcnetdev/marc2bibframe2/releases/tag/v2.9.0-dev"
      },
      "status": {
        "@id": "http://id.loc.gov/vocabulary/mstatus/c",
        "@type": "Status",
        "code": "c",
        "rdfs:label": "changed"
      }
    },
    {
      "@type": "AdminMetadata",
      "bflc:encodingLevel": {
        "@id": "http://id.loc.gov/vocabulary/menclvl/f",
        "@type": "bflc:EncodingLevel",
        "code": "f",
        "rdfs:label": "full"
      },
      "descriptionAuthentication": {
        "@id": "http://id.loc.gov/vocabulary/marcauthen/lccopycat",
        "@type": "DescriptionAuthentication",
        "code": "lccopycat",
        "rdfs:label": "LC Copy Cataloging"
      },
      "descriptionConventions": [
        {
          "@id": "http://id.loc.gov/vocabulary/descriptionConventions/isbd",
          "@type": "DescriptionConventions",
          "code": "isbd",
          "rdfs:label": "ISBD: International standard bibliographic description"
        },
        {
          "@id": "http://id.loc.gov/vocabulary/descriptionConventions/rda",
          "@type": "DescriptionConventions",
          "code": "rda",
          "rdfs:label": "Resource description and access"
        }
      ],
      "descriptionLanguage": {
        "@id": "http://id.loc.gov/vocabulary/languages/eng",
        "@type": "Language",
        "code": {
          "@type": "http://www.w3.org/2001/XMLSchema#string",
          "@value": "eng"
        },
        "rdfs:label": {
          "@language": "en",
          "@value": "English"
        }
      },
      "descriptionLevel": {
        "@id": "http://id.loc.gov/ontologies/bibframe-2-4-0/"
      },
      "identifiedBy": {
        "@type": "Local",
        "assigner": {
          "@id": "http://id.loc.gov/vocabulary/organizations/dlc",
          "@type": [
            "Organization",
            "Agent",
            "mads:CorporateName"
          ],
          "code": [
            {
              "@type": "http://id.loc.gov/datatypes/orgs/code",
              "@value": "DLC"
            },
            {
              "@type": "http://id.loc.gov/datatypes/orgs/normalized",
              "@value": "dlc"
            },
            {
              "@type": "http://id.loc.gov/datatypes/orgs/iso15511",
              "@value": "US-dlc"
            }
          ],
          "rdfs:label": "United States, Library of Congress"
        },
        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value": "24042045"
      },
      "note": {
        "@type": [
          "Note",
          "http://id.loc.gov/vocabulary/mnotetype/internal"
        ],
        "rdfs:label": "040  $aFr-PaAMA$beng$erda$cFr-PaAMA$dDLC"
      },
      "http://id.loc.gov/ontologies/lclocal/d906": "=906     $a 7 $b cbc $c copycat $d 3 $e ncip $f 20 $g y-gencatlg",
      "http://id.loc.gov/ontologies/lclocal/d925": "=925  0  $a acquire $b 1 shelf copy $x policy default",
      "http://id.loc.gov/ontologies/lclocal/d955": "=955     $a am00 2025-02-25 item has been shipped $a bd25 2025-03-12 item received; to PresSrvs",
      "http://id.loc.gov/ontologies/lclocal/d985": "=985     $a shelf ready $e AM-FY25"
    }
  ],
  "classification": {
    "@type": "ClassificationLcc",
    "assigner": {
      "@id": "http://id.loc.gov/vocabulary/organizations/dlc",
      "@type": [
        "Organization",
        "Agent",
        "mads:CorporateName"
      ],
      "code": [
        {
          "@type": "http://id.loc.gov/datatypes/orgs/code",
          "@value": "DLC"
        },
        {
          "@type": "http://id.loc.gov/datatypes/orgs/normalized",
          "@value": "dlc"
        },
        {
          "@type": "http://id.loc.gov/datatypes/orgs/iso15511",
          "@value": "US-dlc"
        }
      ],
      "rdfs:label": "United States, Library of Congress"
    },
    "classificationPortion": "PQ2702.E298",
    "itemPortion": "M36 2024",
    "status": {
      "@id": "http://id.loc.gov/vocabulary/mstatus/uba",
      "@type": "Status",
      "code": "uba",
      "rdfs:label": "used by assigner"
    }
  },
  "content": {
    "@id": "http://id.loc.gov/vocabulary/contentTypes/txt",
    "@type": "Content",
    "code": "txt",
    "rdfs:label": "text"
  },
  "contribution": {
    "@type": [
      "Contribution",
      "PrimaryContribution"
    ],
    "agent": {
      "@id": "http://id.loc.gov/rwo/agents/no2012149645",
      "@type": [
        "Agent",
        "Person"
      ],
      "bflc:marcKey": "1001 $aBecker, Emma,$d1988-",
      "rdfs:label": "Becker, Emma, 1988-"
    },
    "role": {
      "@id": "http://id.loc.gov/vocabulary/relators/aut",
      "@type": "Role",
      "code": "aut",
      "rdfs:label": "author"
    }
  },
  "genreForm": {
    "@id": "http://id.loc.gov/authorities/genreForms/gf2014026339",
    "@type": "GenreForm",
    "bflc:marcKey": "155  $aFiction",
    "rdfs:label": {
      "@language": "en",
      "@value": "Fiction"
    }
  },
  "hasInstance": {
    "@id": "http://id.loc.gov/resources/instances/24042045",
    "@type": "Instance",
    "adminMetadata": [
      {
        "@type": "AdminMetadata",
        "agent": {
          "@type": "Agent",
          "code": "Fr-PaAMA"
        },
        "date": {
          "@type": "http://www.w3.org/2001/XMLSchema#date",
          "@value": "2024-07-04"
        },
        "status": {
          "@id": "http://id.loc.gov/vocabulary/mstatus/n",
          "@type": "Status",
          "code": "n",
          "rdfs:label": "new"
        }
      },
      {
        "@type": "AdminMetadata",
        "date": {
          "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
          "@value": "2025-03-12T08:27:48"
        },
        "descriptionModifier": {
          "@id": "http://id.loc.gov/vocabulary/organizations/dlc",
          "@type": [
            "Organization",
            "Agent",
            "mads:CorporateName"
          ],
          "code": [
            {
              "@type": "http://id.loc.gov/datatypes/orgs/code",
              "@value": "DLC"
            },
            {
              "@type": "http://id.loc.gov/datatypes/orgs/normalized",
              "@value": "dlc"
            },
            {
              "@type": "http://id.loc.gov/datatypes/orgs/iso15511",
              "@value": "US-dlc"
            }
          ],
          "rdfs:label": "United States, Library of Congress"
        },
        "status": {
          "@id": "http://id.loc.gov/vocabulary/mstatus/c",
          "@type": "Status",
          "code": "c",
          "rdfs:label": "changed"
        }
      },
      {
        "@type": "AdminMetadata",
        "agent": {
          "@id": "http://id.loc.gov/vocabulary/organizations/dlcmrc",
          "@type": [
            "Agent",
            "Organization"
          ],
          "code": [
            {
              "@type": "http://id.loc.gov/datatypes/orgs/code",
              "@value": "DLC-MRC"
            },
            {
              "@type": "http://id.loc.gov/datatypes/orgs/normalized",
              "@value": "dlcmrc"
            },
            {
              "@type": "http://id.loc.gov/datatypes/orgs/iso15511",
              "@value": "US-dlcmrc"
            }
          ],
          "rdfs:label": "United States, Library of Congress, Network Development and MARC Standards Office"
        },
        "date": {
          "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
          "@value": "2025-03-13T01:59:54.733430-04:00"
        },
        "generationProcess": {
          "@id": "https://github.com/lcnetdev/marc2bibframe2/releases/tag/v2.9.0-dev"
        },
        "status": {
          "@id": "http://id.loc.gov/vocabulary/mstatus/c",
          "@type": "Status",
          "code": "c",
          "rdfs:label": "changed"
        }
      },
      {
        "@type": "AdminMetadata",
        "bflc:encodingLevel": {
          "@id": "http://id.loc.gov/vocabulary/menclvl/f",
          "@type": "bflc:EncodingLevel",
          "code": "f",
          "rdfs:label": "full"
        },
        "descriptionAuthentication": {
          "@id": "http://id.loc.gov/vocabulary/marcauthen/lccopycat",
          "@type": "DescriptionAuthentication",
          "code": "lccopycat",
          "rdfs:label": "LC Copy Cataloging"
        },
        "descriptionConventions": [
          {
            "@id": "http://id.loc.gov/vocabulary/descriptionConventions/isbd",
            "@type": "DescriptionConventions",
            "code": "isbd",
            "rdfs:label": "ISBD: International standard bibliographic description"
          },
          {
            "@id": "http://id.loc.gov/vocabulary/descriptionConventions/rda",
            "@type": "DescriptionConventions",
            "code": "rda",
            "rdfs:label": "Resource description and access"
          }
        ],
        "descriptionLanguage": {
          "@id": "http://id.loc.gov/vocabulary/languages/eng",
          "@type": "Language",
          "code": {
            "@type": "http://www.w3.org/2001/XMLSchema#string",
            "@value": "eng"
          },
          "rdfs:label": {
            "@language": "en",
            "@value": "English"
          }
        },
        "descriptionLevel": {
          "@id": "http://id.loc.gov/ontologies/bibframe-2-4-0/"
        },
        "identifiedBy": {
          "@type": "Local",
          "assigner": {
            "@id": "http://id.loc.gov/vocabulary/organizations/dlc",
            "@type": [
              "Organization",
              "Agent",
              "mads:CorporateName"
            ],
            "code": [
              {
                "@type": "http://id.loc.gov/datatypes/orgs/code",
                "@value": "DLC"
              },
              {
                "@type": "http://id.loc.gov/datatypes/orgs/normalized",
                "@value": "dlc"
              },
              {
                "@type": "http://id.loc.gov/datatypes/orgs/iso15511",
                "@value": "US-dlc"
              }
            ],
            "rdfs:label": "United States, Library of Congress"
          },
          "http://www.w3.org/1999/02/22-rdf-syntax-ns#value": "24042045"
        },
        "note": {
          "@type": [
            "Note",
            "http://id.loc.gov/vocabulary/mnotetype/internal"
          ],
          "rdfs:label": "040  $aFr-PaAMA$beng$erda$cFr-PaAMA$dDLC"
        },
        "http://id.loc.gov/ontologies/lclocal/d906": "=906     $a 7 $b cbc $c copycat $d 3 $e ncip $f 20 $g y-gencatlg",
        "http://id.loc.gov/ontologies/lclocal/d925": "=925  0  $a acquire $b 1 shelf copy $x policy default",
        "http://id.loc.gov/ontologies/lclocal/d955": "=955     $a am00 2025-02-25 item has been shipped $a bd25 2025-03-12 item received; to PresSrvs",
        "http://id.loc.gov/ontologies/lclocal/d985": "=985     $a shelf ready $e AM-FY25"
      }
    ],
    "carrier": {
      "@id": "http://id.loc.gov/vocabulary/carriers/nc",
      "@type": "Carrier",
      "code": "nc",
      "rdfs:label": "volume"
    },
    "dimensions": "21 cm",
    "extent": {
      "@type": "Extent",
      "rdfs:label": "409 pages"
    },
    "identifiedBy": [
      {
        "@type": "Lccn",
        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value": "  2024384167"
      },
      {
        "@type": "Isbn",
        "qualifier": "paperback",
        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value": "9782226489784"
      },
      {
        "@type": "Local",
        "assigner": {
          "@id": "http://id.loc.gov/vocabulary/organizations/frpaama",
          "@type": "Organization",
          "code": [
            {
              "@type": "http://id.loc.gov/datatypes/orgs/code",
              "@value": "FR-PaAMA"
            },
            {
              "@type": "http://id.loc.gov/datatypes/orgs/normalized",
              "@value": "frpaama"
            }
          ],
          "rdfs:label": "AMALIVRE"
        },
        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value": "AAL08388212-0001"
      }
    ],
    "instanceOf": {
      "@id": "http://id.loc.gov/resources/works/24042045"
    },
    "issuance": {
      "@id": "http://id.loc.gov/vocabulary/issuance/mono",
      "@type": "Issuance",
      "code": "mono",
      "rdfs:label": "single unit"
    },
    "media": {
      "@id": "http://id.loc.gov/vocabulary/mediaTypes/n",
      "@type": "Media",
      "code": "n",
      "rdfs:label": "unmediated"
    },
    "provisionActivity": {
      "@type": [
        "ProvisionActivity",
        "Publication"
      ],
      "bflc:simpleAgent": "Albin Michel",
      "bflc:simpleDate": "[2024]",
      "bflc:simplePlace": "Paris",
      "date": {
        "@type": "http://id.loc.gov/datatypes/edtf",
        "@value": "2024"
      },
      "place": {
        "@id": "http://id.loc.gov/vocabulary/countries/fr",
        "@type": "Place",
        "code": {
          "@type": "http://www.w3.org/2001/XMLSchema#string",
          "@value": "fr"
        },
        "rdfs:label": {
          "@language": "en",
          "@value": "France"
        }
      }
    },
    "publicationStatement": "Paris: Albin Michel, [2024]",
    "responsibilityStatement": "Emma Becker",
    "title": {
      "@type": "Title",
      "bflc:nonSortNum": "3",
      "mainTitle": "Le mal joli",
      "subtitle": "roman"
    },
    "http://purl.org/dc/terms/isPartOf": {
      "@id": "http://id.loc.gov/resources/instances"
    }
  },
  "language": {
    "@id": "http://id.loc.gov/vocabulary/languages/fre",
    "@type": "Language",
    "code": {
      "@type": "http://www.w3.org/2001/XMLSchema#string",
      "@value": "fre"
    },
    "rdfs:label": {
      "@language": "en",
      "@value": "French"
    }
  },
  "title": {
    "@type": "Title",
    "bflc:nonSortNum": "3",
    "mainTitle": "Le mal joli"
  },
  "http://purl.org/dc/terms/isPartOf": {
    "@id": "http://id.loc.gov/resources/works"
  }
}
```

I used this little program that felt like it should be shorter:

```python
import json

import rdflib

from bluecore_models.bluecore_graph import BluecoreGraph
from bluecore_models.utils.graph import frame_jsonld
from bluecore_models.namespaces import BF

g = rdflib.Graph()
g.parse('sample/batch.jsonld')
bg = BluecoreGraph(g)

batch = []

for w in bg.works():
    uri = w.value(predicate=rdflib.RDF.type, object=BF.Work)
    if type(uri) is rdflib.BNode:
        return None

    jsonld = json.loads(g.serialize(format="json-ld"))
    jsonld = frame_jsonld(str(uri), jsonld)
    batch.append(jsonld)

json.dump(batch, open("sample/batch.jsonld", "w"), indent=2)
```

## How was this change tested?

I ensured that the new sample metadata was readable as JSON-LD

## Which documentation and/or configurations were updated?

n/a




