### PR TITLE
27 lchs headings fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-api"
-version = "0.16.2"
+version = "0.16.3"
 description = "Blue Core API for managing BIBFRAME RDF data and workflows"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/bluecore_api/app/utils/serializer/cbd.py
+++ b/src/bluecore_api/app/utils/serializer/cbd.py
@@ -14,6 +14,7 @@ from bluecore_models.utils.graph import load_jsonld
 
 BF_NAMESPACE = Namespace("http://id.loc.gov/ontologies/bibframe/")
 RDF_NAMESPACE = Namespace("http://www.w3.org/1999/02/22-rdf-syntax-ns#")
+MADSRDF_NAMESPACE = Namespace("http://www.loc.gov/mads/rdf/v1#")
 XPATH_NAMESPACES = {
     "bf": str(BF_NAMESPACE),
     "rdf": str(RDF_NAMESPACE),
@@ -67,6 +68,7 @@ def generate_cbd_graph(instance: Instance) -> Graph:
             instance_graph = expand_resource_as_graph(related_instance, instance_graph)
 
     instance_graph.bind("bf", BF_NAMESPACE, override=True, replace=True)
+    instance_graph.bind("madsrdf", MADSRDF_NAMESPACE, override=True, replace=True)
     return instance_graph
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -81,7 +81,7 @@ wheels = [
 
 [[package]]
 name = "bluecore-api"
-version = "0.16.2"
+version = "0.16.3"
 source = { editable = "." }
 dependencies = [
     { name = "bluecore-models" },


### PR DESCRIPTION
## MVP Issues Resolved
* https://github.com/blue-core-lod/marva_editor/issues/27
* https://github.com/blue-core-lod/marva_editor/issues/28
* https://github.com/blue-core-lod/marva_editor/issues/29



## Why was this change made?

Marva does string-level matching on serialized RDF/XML property names and only recognizes MADS properties when they are prefixed `madsrdf:`. The CBD serializer was using the `mads:` prefix from the source JSON-LD `@context`, so subjects with `mads:authoritativeLabel`, `mads:componentList`, etc. were not being recognized by Marva (no green checkmarks on FAST/LCSH subjects). 

Explicitly binding the MADS namespace to `madsrdf` in `generate_cbd_graph` forces rdflib to serialize those properties with the prefix Marva expects, matching the LC reference output.

  ## How was this change tested?

- Loaded instance ("Tea for one") in the local Marva editor against the dev API and confirmed the FAST and LCSH subjects now render with green checkmarks. 
- Verified the generated CBD XML now declares `xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"` and outputs `<madsrdf:authoritativeLabel>`, `<madsrdf:componentList>`, and `<madsrdf:isMemberOfMADSScheme>` in place of the previous `mads:` prefixed forms.

Before fix:
<img width="328" height="1296" alt="image" src="https://github.com/user-attachments/assets/296a91ca-1194-4c3e-8095-95be9396c124" />


After Fix:
<img width="328" height="1296" alt="image" src="https://github.com/user-attachments/assets/d4c1fa8d-bf58-4875-9fa8-c88d49cc6267" />


## Which documentation and/or configurations were updated?

N/A