### PR TITLE
script: added LC CBD.XML to JSON-LD convert script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .cognitoToken
 __pycache__*
 uploads
+/.idea

--- a/README.md
+++ b/README.md
@@ -88,13 +88,44 @@ The application should then be available at http://localhost:3000
 
 ## 💾 Load Data
 
-If you want to try loading some data you can use the `bluecore` utility:
+If you want to try loading some data you can use the `bluecore` utility.
+
+### Load from a URL
 
 ```shell
 uv run bluecore --verbose load-url https://raw.githubusercontent.com/blue-core-lod/bluecore_api/refs/heads/main/sample/batch.jsonld
 ```
 
 This will tell the Blue Core API to load the data at that URL into the database.
+
+### Load from a local file
+To batch load a file from your local filesystem (the local equivalent of the
+URL load above), use `load-file` and point it at a JSON-LD document — for
+example one of the samples in `sample/`:
+
+```shell
+uv run bluecore --verbose load-file sample/batch-small.jsonld
+```
+
+## 🔄 Converting a Library of Congress CBD to JSON-LD
+LC publishes resources as `*.cbd.xml` (RDF/XML). The
+`scripts/cbd_to_jsonld.py` helper downloads one and converts it to JSON-LD so
+it can be batch loaded like any other sample.
+
+Pass the `.cbd.xml` URL; the instance id is taken from the URL and the result
+is written to `sample/<INSTANCE_ID>.jsonld`:
+
+```shell
+uv run python scripts/cbd_to_jsonld.py https://id.loc.gov/resources/instances/22442890.cbd.xml
+# → writes sample/22442890.jsonld
+```
+
+Use `--out-dir` to write somewhere else. Once converted, load it locally with
+`load-file`:
+
+```shell
+uv run bluecore --verbose load-file sample/22442890.jsonld
+```
 
 ## 📡 HTTP Requests
 

--- a/scripts/cbd_to_jsonld.py
+++ b/scripts/cbd_to_jsonld.py
@@ -8,17 +8,26 @@ Example:
     uv run python scripts/cbd_to_jsonld.py https://id.loc.gov/resources/instances/22442890.cbd.xml
 
 Given a URL ending in ``<INSTANCE_ID>.cbd.xml``, the CBD (RDF/XML) is fetched,
-parsed with rdflib, and written out as ``<INSTANCE_ID>.jsonld`` in the repo's
-``sample/`` directory (override with ``--out-dir``).
+parsed with rdflib, and framed into the Blue Core batch shape — an array with
+one framed document per Work, matching ``sample/batch.jsonld``. The result is
+written to ``sample/<INSTANCE_ID>.jsonld`` (override with ``--out-dir``) so it
+can be loaded with ``uv run bluecore load-file``.
+
+Must be run via ``uv run`` so the ``bluecore_models`` framing helpers are
+importable.
 """
 
 import argparse
+import json
 import re
 import sys
 import urllib.request
 from pathlib import Path
 
-from rdflib import Graph
+import rdflib
+from bluecore_models.bluecore_graph import BluecoreGraph
+from bluecore_models.namespaces import BF
+from bluecore_models.utils.graph import frame_jsonld
 
 # matches the trailing "<id>.cbd.xml" portion of a LoC resource URL
 INSTANCE_ID_RE = re.compile(r"([^/]+?)\.cbd\.xml$", re.IGNORECASE)
@@ -44,11 +53,29 @@ def download(url: str) -> bytes:
         return response.read()
 
 
-def cbd_xml_to_jsonld(xml_bytes: bytes) -> str:
-    """Parse RDF/XML and re-serialize as pretty JSON-LD."""
-    graph = Graph()
+def cbd_xml_to_batch(xml_bytes: bytes) -> list[dict]:
+    """Parse RDF/XML and frame it into the Blue Core batch shape.
+
+    Returns a list with one framed JSON-LD document per named Work in the
+    graph, the same structure as ``sample/batch.jsonld``. Blank-node Works
+    (e.g. the embedded "other physical format" stub) are skipped — they're
+    pulled in as nested resources of the Work that references them.
+    """
+    graph = rdflib.Graph()
     graph.parse(data=xml_bytes, format="xml")
-    return graph.serialize(format="json-ld", indent=2)
+
+    bluecore_graph = BluecoreGraph(graph)
+    jsonld_data = json.loads(graph.serialize(format="json-ld"))
+
+    batch = []
+    for work in bluecore_graph.works():
+        uri = work.value(predicate=rdflib.RDF.type, object=BF.Work)
+        if uri is None or isinstance(uri, rdflib.BNode):
+            # only named Works become top-level batch documents
+            continue
+        batch.append(frame_jsonld(str(uri), jsonld_data))
+
+    return batch
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -67,14 +94,17 @@ def main(argv: list[str] | None = None) -> int:
     print(f"Downloading {args.url} ...", file=sys.stderr)
     xml_bytes = download(args.url)
 
-    print("Converting CBD XML to JSON-LD ...", file=sys.stderr)
-    jsonld = cbd_xml_to_jsonld(xml_bytes)
+    print("Converting CBD XML to framed JSON-LD ...", file=sys.stderr)
+    batch = cbd_xml_to_batch(xml_bytes)
+    if not batch:
+        print("No named Work found in the CBD — nothing written.", file=sys.stderr)
+        return 1
 
     args.out_dir.mkdir(parents=True, exist_ok=True)
     out_path = args.out_dir / f"{instance_id}.jsonld"
-    out_path.write_text(jsonld, encoding="utf-8")
+    out_path.write_text(json.dumps(batch, indent=2), encoding="utf-8")
 
-    print(f"Wrote {out_path}", file=sys.stderr)
+    print(f"Wrote {out_path} ({len(batch)} work(s))", file=sys.stderr)
     return 0
 
 

--- a/scripts/cbd_to_jsonld.py
+++ b/scripts/cbd_to_jsonld.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+"""Download a Library of Congress *.cbd.xml resource and convert it to JSON-LD.
+
+Usage:
+    uv run python scripts/cbd_to_jsonld.py <CBD_XML_URL>
+
+Example:
+    uv run python scripts/cbd_to_jsonld.py https://id.loc.gov/resources/instances/22442890.cbd.xml
+
+Given a URL ending in ``<INSTANCE_ID>.cbd.xml``, the CBD (RDF/XML) is fetched,
+parsed with rdflib, and written out as ``<INSTANCE_ID>.jsonld`` in the repo's
+``sample/`` directory (override with ``--out-dir``).
+"""
+
+import argparse
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+from rdflib import Graph
+
+# matches the trailing "<id>.cbd.xml" portion of a LoC resource URL
+INSTANCE_ID_RE = re.compile(r"([^/]+?)\.cbd\.xml$", re.IGNORECASE)
+
+# default output location: the repo's sample/ directory (scripts/ is one level down)
+DEFAULT_OUT_DIR = Path(__file__).resolve().parent.parent / "sample"
+
+
+def instance_id_from_url(url: str) -> str:
+    """Pull the instance id out of a ``.../<id>.cbd.xml`` URL."""
+    match = INSTANCE_ID_RE.search(url)
+    if not match:
+        raise ValueError(f"URL does not look like a *.cbd.xml resource: {url}")
+    return match.group(1)
+
+
+def download(url: str) -> bytes:
+    """Fetch the CBD XML, requesting RDF/XML explicitly."""
+    request = urllib.request.Request(
+        url, headers={"Accept": "application/rdf+xml, application/xml"}
+    )
+    with urllib.request.urlopen(request) as response:
+        return response.read()
+
+
+def cbd_xml_to_jsonld(xml_bytes: bytes) -> str:
+    """Parse RDF/XML and re-serialize as pretty JSON-LD."""
+    graph = Graph()
+    graph.parse(data=xml_bytes, format="xml")
+    return graph.serialize(format="json-ld", indent=2)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("url", help="LoC *.cbd.xml resource URL")
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=DEFAULT_OUT_DIR,
+        help="directory to write <INSTANCE_ID>.jsonld into (default: the repo's sample/ dir)",
+    )
+    args = parser.parse_args(argv)
+
+    instance_id = instance_id_from_url(args.url)
+
+    print(f"Downloading {args.url} ...", file=sys.stderr)
+    xml_bytes = download(args.url)
+
+    print("Converting CBD XML to JSON-LD ...", file=sys.stderr)
+    jsonld = cbd_xml_to_jsonld(xml_bytes)
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = args.out_dir / f"{instance_id}.jsonld"
+    out_path.write_text(jsonld, encoding="utf-8")
+
+    print(f"Wrote {out_path}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why was this change made?
Add a helper script for quickly converting Library of Congress *.cbd.xml resources into Blue Core–loadable JSON-LD. Pass it an LC resource URL and it downloads the CBD, converts it, and saves it to sample/<INSTANCE_ID>.jsonld.

Example usage: 
`uv run python scripts/cbd_to_jsonld.py https://id.loc.gov/resources/instances/22442890.cbd.xml`

## How was this change tested?
Locally ran and injested JSON-LD sucessfully


## Which documentation and/or configurations were updated?
Updated the README to show how to use.


