### PR TITLE
37 marva white screen fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .cognitoToken
 __pycache__*
 uploads
+/.idea

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-api"
-version = "0.16.3"
+version = "0.16.4"
 description = "Blue Core API for managing BIBFRAME RDF data and workflows"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/bluecore_api/app/utils/serializer/cbd.py
+++ b/src/bluecore_api/app/utils/serializer/cbd.py
@@ -20,6 +20,16 @@ XPATH_NAMESPACES = {
     "rdf": str(RDF_NAMESPACE),
 }
 
+# Resource types kept as top-level siblings in the CBD XML instead of being
+# nested inside the elements that reference them. Marva expects Works,
+# Instances, and Items to stay at the top level, linked only by rdf:resource.
+TOP_LEVEL_TYPES = (BibframeType.WORK, BibframeType.INSTANCE, BibframeType.ITEM)
+
+
+def top_level_resource(elem) -> bool:
+    """Whether an element is a Work/Instance/Item that should not be nested."""
+    return any(elem.tag.endswith(bf_type) for bf_type in TOP_LEVEL_TYPES)
+
 
 def reorder_work_types(work_data: dict[str, Any]) -> dict[str, Any]:
     """Reorder work types to ensure 'Work' is first"""
@@ -89,9 +99,7 @@ def generate_cbd_xml(graph: Graph):
         graph.serialize(format="pretty-xml", indent=2, max_depth=1).encode("utf-8")
     )
     for elem in root:
-        if elem.tag.endswith(BibframeType.WORK) or elem.tag.endswith(
-            BibframeType.INSTANCE
-        ):
+        if top_level_resource(elem):
             continue
 
         about = elem.xpath("@rdf:about", namespaces=XPATH_NAMESPACES)
@@ -106,9 +114,7 @@ def generate_cbd_xml(graph: Graph):
             match.append(copy.deepcopy(elem))
 
     for elem in root:
-        if elem.tag.endswith(BibframeType.WORK) or elem.tag.endswith(
-            BibframeType.INSTANCE
-        ):
+        if top_level_resource(elem):
             continue
         root.remove(elem)
 

--- a/src/bluecore_api/constants.py
+++ b/src/bluecore_api/constants.py
@@ -20,6 +20,7 @@ class BibframeType(StringEnum):
 
     WORK = "Work"
     INSTANCE = "Instance"
+    ITEM = "Item"
 
 
 class SearchType(StringEnum):

--- a/uv.lock
+++ b/uv.lock
@@ -81,7 +81,7 @@ wheels = [
 
 [[package]]
 name = "bluecore-api"
-version = "0.16.3"
+version = "0.16.4"
 source = { editable = "." }
 dependencies = [
     { name = "bluecore-models" },


### PR DESCRIPTION
### Resolves Issue: https://github.com/blue-core-lod/marva_editor/issues/37
### Instances that uncovered Issue: 
* https://dev.bcld.info/instances/646276f9-527d-4736-ac77-cc8c13e64064
* https://dev.bcld.info/instances/0fedcb7d-1c0b-4ba2-8199-7bd6b9fdd590


## Why was this change made?
When creating a CBD, if an Item existed it was being nested inside `<bf:hasItem>` instead of staying a top-level resource. 
The XML post-processing in cbd.py only protected Work and Instance from being inlined, so Item got swept into the element that referenced it. Marva couldn't parse this and rendered nothing. 

This change adds Item to the set of top-level resource types, so it stays a sibling of Work/Instance and bf:hasItem serializes as a flat rdf:resource reference — matching the structure LC produces.

## How was this change tested?
Ran the existing CBD serializer tests (uv run pytest tests/api/test_cbd.py) — all pass. Verified locally with a reproduction graph that an Item now renders as a top-level element with bf:hasItem as an rdf:resource reference, rather than being nested. Ruff check + format pass.


## Which documentation and/or configurations were updated?
N/A

## Screenshots

### Before:
<img width="2121" height="1043" alt="image" src="https://github.com/user-attachments/assets/4982ddc0-96e3-4802-a9fa-69266da70102" />


### After:
<img width="2121" height="1306" alt="image" src="https://github.com/user-attachments/assets/3c77bdb0-a93a-44d5-8acb-3aa9d715b9a6" />


