### PR TITLE
Feat/organized api doc endpoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-api"
-version = "0.16.4"
+version = "0.16.5"
 description = "Blue Core API for managing BIBFRAME RDF data and workflows"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/bluecore_api/app/main.py
+++ b/src/bluecore_api/app/main.py
@@ -40,10 +40,22 @@ OpenAPI tag metadata. The order here is the order sections appear in the /docs a
 openapi_tags = [
     {"name": "Works", "description": "BIBFRAME Works."},
     {"name": "Instances", "description": "BIBFRAME Instances belonging to a Work."},
-    {"name": "Resources", "description": "JSON or JSON-LD resources used to support Work and Instances.",},
-    {"name": "Search","description": "Full-text and vector search for Works, Instances, Resources.",},
-    {"name": "CBD","description": "Concise Bounded Description serialization consumed by the Marva editor.",},
-    {"name": "Change Documents","description": "Activity Streams change feeds for downstream consumers.",},
+    {
+        "name": "Resources",
+        "description": "JSON or JSON-LD resources used to support Work and Instances.",
+    },
+    {
+        "name": "Search",
+        "description": "Full-text and vector search for Works, Instances, Resources.",
+    },
+    {
+        "name": "CBD",
+        "description": "Concise Bounded Description serialization consumed by the Marva editor.",
+    },
+    {
+        "name": "Change Documents",
+        "description": "Activity Streams change feeds for downstream consumers.",
+    },
     {"name": "Batches", "description": "Bulk ingestion via Airflow."},
     {"name": "Export", "description": "Resource export."},
 ]

--- a/src/bluecore_api/app/main.py
+++ b/src/bluecore_api/app/main.py
@@ -34,16 +34,39 @@ from bluecore_api.app.routes.batches import endpoints as batch_endpoints
 """Initialize logging config"""
 setup_logging()
 
+"""
+OpenAPI tag metadata. The order here is the order sections appear in the /docs and /redoc pages.
+"""
+openapi_tags = [
+    {"name": "Works", "description": "BIBFRAME Works."},
+    {"name": "Instances", "description": "BIBFRAME Instances belonging to a Work."},
+    {"name": "Resources", "description": "JSON or JSON-LD resources used to support Work and Instances.",},
+    {"name": "Search","description": "Full-text and vector search for Works, Instances, Resources.",},
+    {"name": "CBD","description": "Concise Bounded Description serialization consumed by the Marva editor.",},
+    {"name": "Change Documents","description": "Activity Streams change feeds for downstream consumers.",},
+    {"name": "Batches", "description": "Bulk ingestion via Airflow."},
+    {"name": "Export", "description": "Resource export."},
+]
+
 """Init base app"""
-base_app = FastAPI(root_path="/api", dependencies=[Depends(set_user_context)])
-base_app.include_router(change_documents)
-base_app.include_router(cbd_endpoints)
-base_app.include_router(instance_routes)
-base_app.include_router(resource_routes)
-base_app.include_router(search_routes)
-base_app.include_router(work_routes)
-base_app.include_router(batch_endpoints)
-base_app.include_router(export_routes)
+base_app = FastAPI(
+    root_path="/api",
+    dependencies=[Depends(set_user_context)],
+    openapi_tags=openapi_tags,
+    swagger_ui_parameters={
+        "displayRequestDuration": True,  # Show response time on each call
+        "filter": True,  # Add a search box to filter operations by name
+        "defaultModelsExpandDepth": 0,  # Start the "Schemas" section collapsed
+    },
+)
+base_app.include_router(work_routes, tags=["Works"])
+base_app.include_router(instance_routes, tags=["Instances"])
+base_app.include_router(resource_routes, tags=["Resources"])
+base_app.include_router(search_routes, tags=["Search"])
+base_app.include_router(cbd_endpoints, tags=["CBD"])
+base_app.include_router(change_documents, tags=["Change Documents"])
+base_app.include_router(batch_endpoints, tags=["Batches"])
+base_app.include_router(export_routes, tags=["Export"])
 
 BLUECORE_URL = os.environ.get("BLUECORE_URL", "https://bcld.info/")
 

--- a/uv.lock
+++ b/uv.lock
@@ -81,7 +81,7 @@ wheels = [
 
 [[package]]
 name = "bluecore-api"
-version = "0.16.4"
+version = "0.16.5"
 source = { editable = "." }
 dependencies = [
     { name = "bluecore-models" },


### PR DESCRIPTION
## Why was this change made?
Groups the API endpoints into labeled, ordered sections and adds a few UI quality-of-life settings. Previously every endpoint rendered in a single untagged "default" bucket on /docs, making the page hard to scan.

#### Changes:
- Tagged every router so endpoints group into sections in both /docs (Swagger UI) and /redoc:                                                                                                                                                                                                                             
  - Works, Instances, Resources, Search, CBD, Change Documents, Batches, Export                                                                                                                                                                                                                                             
- Added openapi_tags metadata with a one-line description per section and an explicit ordering (the four primary resources first: Works → Instances → Resources → Search, followed by CBD, Change Documents, Batches, Export).                                                                                                     
- Added swagger_ui_parameters for usability:                                                                                                                                                                                                                                                                           
    - `displayRequestDuration: True` — shows response time after each call                                                                                                                                                                                                                                                    
    - `filter: True `— adds a search box to filter operations by name                                                                                                                                                                                                                                                         
    - `defaultModelsExpandDepth: 0` — keeps the "Schemas" section but renders it collapsed instead of expanded by default

## How was this change tested?
Locally 
### Before:
<img width="732" height="1266" alt="image" src="https://github.com/user-attachments/assets/92e409e7-0e97-452f-a571-b9e1023e0df3" />

### After:
<img width="732" height="1217" alt="image" src="https://github.com/user-attachments/assets/ba706202-4337-47c8-81a5-5469b97dac43" />


## Which documentation and/or configurations were updated?

N/A


