### PR TITLE
Fix Slack dependency-updates-notify text

### DIFF
--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -83,7 +83,8 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           PR_URL: ${{ steps.create_pr.outputs.pull-request-url }}
           NEW_VERSION: ${{ steps.bump_version.outputs.new_version }}
+          REPO_NAME: ${{ github.event.repository.name }}
         run: |
           curl -X POST -H 'Content-type: application/json' \
-            --data "{\"text\": \"bluecore-workflows dependency update PR opened: <$PR_URL|v$NEW_VERSION>\"}" \
+            --data "{\"text\": \"${REPO_NAME} dependency update PR opened: <$PR_URL|v$NEW_VERSION>\"}" \
             "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
## Why was this change made?
Use `github.event.repository.name` instead of hardcoded repo name.


## How was this change tested?



## Which documentation and/or configurations were updated?




