### PR TITLE
Add api endpoints for the new Hub model

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-api"
-version = "0.17.1"
+version = "0.18.1"
 description = "Blue Core API for managing BIBFRAME RDF data and workflows"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -10,7 +10,7 @@ dependencies = [
   "pgvector",
   "psycopg2-binary>=2.9.10",
   "rdflib>=7.1.3",
-  "bluecore-models>=0.12.0",
+  "bluecore-models>=0.14.0",
   "python-multipart>=0.0.20",
   "fastapi-keycloak-middleware>=1.2.0",
   "typer>=0.15.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
   "pgvector",
   "psycopg2-binary>=2.9.10",
   "rdflib>=7.1.3",
-  "bluecore-models>=0.14.0",
+  "bluecore-models>=0.14.1",
   "python-multipart>=0.0.20",
   "fastapi-keycloak-middleware>=1.2.0",
   "typer>=0.15.4",

--- a/src/bluecore_api/app/main.py
+++ b/src/bluecore_api/app/main.py
@@ -31,6 +31,7 @@ from bluecore_api.middleware.keycloak_auth import (
     set_user_context,
 )
 from bluecore_api.middleware.redirect_headers import RedirectLocationMiddleware
+from bluecore_api.app.routes.hubs import endpoints as hub_routes
 
 """Initialize logging config"""
 setup_logging()
@@ -68,6 +69,7 @@ base_app = FastAPI(
         "defaultModelsExpandDepth": 0,  # Start the "Schemas" section collapsed
     },
 )
+base_app.include_router(hub_routes, tags=["Hubs"])
 base_app.include_router(work_routes, tags=["Works"])
 base_app.include_router(instance_routes, tags=["Instances"])
 base_app.include_router(resource_routes, tags=["Resources"])

--- a/src/bluecore_api/app/routes/hubs.py
+++ b/src/bluecore_api/app/routes/hubs.py
@@ -1,0 +1,144 @@
+import os
+import json
+
+from datetime import datetime, UTC
+
+from pymilvus import MilvusClient
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi_keycloak_middleware import CheckPermissions
+
+from sqlalchemy.orm import Session
+
+from bluecore_models.models import Hub
+from bluecore_models.utils.graph import handle_external_subject
+from bluecore_models.utils.vector_db import create_embeddings
+
+from bluecore_api.database import filter_vector_result, get_db, get_vector_client
+from bluecore_api.schemas.schemas import (
+    HubCreateSchema,
+    HubEmbeddingSchema,
+    HubSchema,
+    HubUpdateSchema,
+)
+from bluecore_api.expansion import expand_resource_graph
+
+endpoints = APIRouter()
+
+BLUECORE_URL = os.environ.get("BLUECORE_URL", "https://bcld.info/")
+
+
+@endpoints.get("/hubs/{hub_uuid}", response_model=HubSchema, operation_id="get_hub")
+async def read_hub(hub_uuid: str, expand: bool = False, db: Session = Depends(get_db)):
+    db_hub = db.query(Hub).filter(Hub.uuid == hub_uuid).first()
+    if db_hub is None:
+        raise HTTPException(status_code=404, detail=f"Hub {hub_uuid} not found")
+    if expand:
+        db_hub.data = expand_resource_graph(db_hub)
+    setattr(db_hub, "is_expanded", expand)
+    return db_hub
+
+
+@endpoints.get(
+    "/hubs/{hub_uuid}/embeddings",
+    response_model=HubEmbeddingSchema,
+    operation_id="get_hub_embedding",
+)
+async def get_embedding(
+    hub_uuid: str,
+    db: Session = Depends(get_db),
+    vector_client: MilvusClient = Depends(get_vector_client),
+):
+    db_hub = db.query(Hub).filter(Hub.uuid == hub_uuid).first()
+
+    if db_hub is None:
+        raise HTTPException(status_code=404, detail=f"Hub {hub_uuid} not found")
+
+    version = max(db_hub.versions, key=lambda version: version.created_at)
+
+    filtered_result = filter_vector_result(vector_client, "hubs", version.id)
+
+    return {
+        "hub_id": db_hub.id,
+        "version_id": version.id,
+        "embedding": filtered_result,
+        "hub_uri": db_hub.uri,
+    }
+
+
+@endpoints.post(
+    "/hubs/",
+    response_model=HubSchema,
+    dependencies=[Depends(CheckPermissions(["create"]))],
+    status_code=201,
+    operation_id="create_hub",
+)
+async def create_hub(hub: HubCreateSchema, db: Session = Depends(get_db)):
+    time_now = datetime.now(UTC)
+    updated_payload = handle_external_subject(
+        data=hub.data, type="hubs", bluecore_base_url=BLUECORE_URL
+    )
+    db_hub = Hub(
+        uri=updated_payload.get("uri"),
+        data=updated_payload.get("data"),
+        uuid=updated_payload.get("uuid"),
+        created_at=time_now,
+        updated_at=time_now,
+    )
+    db.add(db_hub)
+    db.commit()
+    db.refresh(db_hub)
+    return db_hub
+
+
+@endpoints.put(
+    "/hubs/{hub_uuid}",
+    response_model=HubSchema,
+    dependencies=[Depends(CheckPermissions(["update"]))],
+    operation_id="update_hub",
+)
+async def update_hub(
+    hub_uuid: str, hub: HubUpdateSchema, db: Session = Depends(get_db)
+):
+    db_hub = db.query(Hub).filter(Hub.uuid == hub_uuid).first()
+    if db_hub is None:
+        raise HTTPException(status_code=404, detail=f"Hub {hub_uuid} not found")
+
+    if hub.data is not None:
+        db_hub.data = json.loads(hub.data)
+
+    db.commit()
+    db.refresh(db_hub)
+    return db_hub
+
+
+@endpoints.post(
+    "/hubs/{hub_uuid}/embeddings",
+    response_model=HubEmbeddingSchema,
+    dependencies=[Depends(CheckPermissions(["create"]))],
+    status_code=201,
+    operation_id="new_hub_embedding",
+)
+async def create_hub_embedding(
+    hub_uuid: str,
+    db: Session = Depends(get_db),
+    vector_client=Depends(get_vector_client),
+):
+    db_hub = db.query(Hub).filter(Hub.uuid == hub_uuid).first()
+    if db_hub is None:
+        raise HTTPException(status_code=404, detail=f"Hub {hub_uuid} not found")
+
+    version = max(db_hub.versions, key=lambda version: version.created_at)
+
+    filtered_result = filter_vector_result(vector_client, "hubs", version.id)
+
+    if len(filtered_result) < 1:
+        create_embeddings(version, "hubs", vector_client)
+        filtered_result = filter_vector_result(vector_client, "hubs", version.id)
+
+    return {
+        "hub_id": db_hub.id,
+        "version_id": version.id,
+        "embedding": filtered_result,
+        "hub_uri": db_hub.uri,
+    }

--- a/src/bluecore_api/constants.py
+++ b/src/bluecore_api/constants.py
@@ -11,6 +11,7 @@ class StringEnum(str, Enum):
 class BluecoreType(StringEnum):
     """Bluecore type enum."""
 
+    HUBS = "hubs"
     WORKS = "works"
     INSTANCES = "instances"
 
@@ -18,6 +19,7 @@ class BluecoreType(StringEnum):
 class BibframeType(StringEnum):
     """Bibframe type enum."""
 
+    HUB = "Hub"
     WORK = "Work"
     INSTANCE = "Instance"
     ITEM = "Item"
@@ -26,6 +28,7 @@ class BibframeType(StringEnum):
 class SearchType(StringEnum):
     """Search type enum."""
 
+    HUBS = "hubs"
     WORKS = "works"
     INSTANCES = "instances"
     ALL = "all"

--- a/src/bluecore_api/middleware/keycloak_auth.py
+++ b/src/bluecore_api/middleware/keycloak_auth.py
@@ -53,10 +53,12 @@ class BypassKeycloakForGet:
     PREFIX_PATHS = {
         "/instances/",
         "/works/",
+        "/hubs/",
         "/resources/",
-        "/api/resources/",
         "/api/instances/",
         "/api/works/",
+        "/api/hubs/",
+        "/api/resources/",
         "/change_documents/",
         "/api/change_documents/",
         "/search",

--- a/src/bluecore_api/schemas/schemas.py
+++ b/src/bluecore_api/schemas/schemas.py
@@ -67,7 +67,29 @@ class OtherResourceUpdateSchema(BaseModel):
     is_profile: Optional[bool] = None
 
 
+class HubCreateSchema(BaseModel):
+    data: str
+
+
+class HubEmbeddingSchema(BaseModel):
+    hub_id: int
+    hub_uri: str
+    version_id: int
+    embedding: list
+
+
+class HubSchema(ResourceBaseSchema):
+    type: str = BluecoreType.HUBS
+    is_expanded: bool = False
+
+
+class HubUpdateSchema(BaseModel):
+    data: Optional[str] = None
+    hub_id: Optional[int] = None
+
+
 class WorkCreateSchema(BaseModel):
+    hub_id: Optional[int] = None
     data: str
 
 
@@ -77,6 +99,7 @@ class WorkUpdateSchema(BaseModel):
 
 class WorkSchema(ResourceBaseSchema):
     type: str = BluecoreType.WORKS
+    hub_id: Optional[int]
     is_expanded: bool = False
 
 

--- a/tests/api/test_hub.py
+++ b/tests/api/test_hub.py
@@ -1,0 +1,215 @@
+import json
+import pathlib
+import pytest
+import rdflib
+
+from bluecore_models.models import BibframeOtherResources, Hub, OtherResource, Version
+from bluecore_models.utils.graph import init_graph, load_jsonld, BF
+from bluecore_models.utils.vector_db import create_embeddings
+
+
+def test_get_hub(client, db_session):
+    test_hub_uuid = "62a26d82-4e65-c696-afed-b12d215a35b1"
+    test_hub_uri = f"http://id.loc.gov/resources/hubs/{test_hub_uuid}"
+    jsonld_data = json.load(pathlib.Path("tests/blue-core-hub.jsonld").open())
+    orig_graph = load_jsonld(jsonld_data)
+
+    db_session.add(
+        Hub(
+            id=1,
+            uuid=test_hub_uuid,
+            uri=test_hub_uri,
+            data=jsonld_data,
+        )
+    )
+
+    response = client.get(f"/hubs/{test_hub_uuid}")
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["uri"].startswith(test_hub_uri)
+
+    fetched_graph = load_jsonld(data["data"])
+    assert len(fetched_graph) == len(orig_graph)
+
+
+def test_get_expanded_hub(client, db_session):
+    hub_uuid = "a1b2c3d4-0000-0000-0000-000000000001"
+    hub_uri = rdflib.URIRef(f"https://bcld.info/hubs/{hub_uuid}")
+    eng_uri = rdflib.URIRef("http://id.loc.gov/vocabulary/languages/eng")
+    hub_graph = init_graph()
+    hub_graph.add((hub_uri, rdflib.RDF.type, BF.Hub))
+    hub_graph.add((hub_uri, BF.language, eng_uri))
+
+    with pathlib.Path("tests/blue-core-other-resources.json").open() as fo:
+        eng_data = json.load(fo)
+
+    hub = Hub(
+        id=1,
+        uuid=hub_uuid,
+        uri=str(hub_uri),
+        data=json.loads(hub_graph.serialize(format="json-ld")),
+    )
+    db_session.add(hub)
+
+    other_resource = OtherResource(id=2, uri=str(eng_uri), data=eng_data)
+    db_session.add(other_resource)
+    bf_other_resource = BibframeOtherResources(
+        id=1,
+        other_resource=other_resource,
+        bibframe_resource=hub,
+    )
+    db_session.add(bf_other_resource)
+    db_session.commit()
+
+    regular_response = client.get(f"/hubs/{hub_uuid}")
+    regular_graph = load_jsonld(regular_response.json()["data"])
+
+    assert len(regular_graph) == 2
+
+    expanded_response = client.get(f"/hubs/{hub_uuid}?expand=true")
+    expanded_graph = load_jsonld(expanded_response.json()["data"])
+
+    assert len(expanded_graph) == 5
+
+
+def test_create_hub(client, mocker):
+    original_graph = init_graph()
+    original_graph.parse(
+        data=pathlib.Path("tests/blue-core-hub.jsonld").read_text(), format="json-ld"
+    )
+
+    payload = {
+        "data": original_graph.serialize(format="json-ld"),
+    }
+    create_response = client.post(
+        "/hubs/", headers={"X-User": "cataloger"}, json=payload
+    )
+
+    assert create_response.status_code == 201
+    data = create_response.json()
+    new_graph = init_graph()
+    new_graph.parse(data=data["data"], format="json-ld")
+
+    assert len(original_graph) != len(new_graph)
+
+    new_hub_uri = rdflib.URIRef(data["uri"])
+    derived_from = new_graph.value(subject=new_hub_uri, predicate=BF.derivedFrom)
+
+    assert str(derived_from).startswith(
+        "http://id.loc.gov/resources/hubs/62a26d82-4e65-c696-afed-b12d215a35b1"
+    )
+
+    assert "created_at" in data
+    assert "updated_at" in data
+    assert data["created_at"] == data["updated_at"], (
+        "created_at and updated_at should match on creation"
+    )
+
+
+def test_update_hub(client, db_session):
+    payload = {
+        "data": pathlib.Path("tests/blue-core-hub.jsonld").read_text(),
+    }
+    create_response = client.post(
+        "/hubs/", headers={"X-User": "cataloger"}, json=payload
+    )
+
+    assert create_response.status_code == 201
+
+    hub_uri = rdflib.URIRef(create_response.json()["uri"])
+    hub_graph = init_graph()
+    data_str = json.dumps(create_response.json()["data"])
+    hub_graph.parse(data=data_str, format="json-ld")
+
+    hub_graph.add(
+        (
+            hub_uri,
+            rdflib.URIRef("https://schema.org/name"),
+            rdflib.Literal("An Updated Hub Name"),
+        )
+    )
+    hub_uuid = create_response.json()["uri"].split("/")[-1]
+    update_response = client.put(
+        f"/hubs/{hub_uuid}",
+        headers={"X-User": "cataloger"},
+        json={"data": hub_graph.serialize(format="json-ld")},
+    )
+
+    assert update_response.status_code == 200
+
+    get_response = client.get(f"/hubs/{hub_uuid}")
+    assert get_response.status_code == 200
+    data = get_response.json()
+
+    updated_hub_graph = init_graph()
+    updated_hub_graph.parse(data=data["data"], format="json-ld")
+
+    name = updated_hub_graph.value(
+        subject=hub_uri,
+        predicate=rdflib.URIRef("https://schema.org/name"),
+    )
+
+    assert str(name) == "An Updated Hub Name"
+
+    assert "created_at" in data
+    assert "updated_at" in data
+    assert data["created_at"] != data["updated_at"], (
+        "created_at and updated_at should not match on update"
+    )
+
+
+def test_get_hub_embedding(client, db_session, vector_client):
+    sample_hub_graph = init_graph()
+    sample_hub_uuid = "a1b2c3d4-0000-0000-0000-000000000002"
+    sample_hub_uri = rdflib.URIRef(f"https://bcld.info/hubs/{sample_hub_uuid}")
+    sample_hub_graph.add((sample_hub_uri, rdflib.RDF.type, BF.Hub))
+    sample_hub_graph.add(
+        (sample_hub_uri, rdflib.RDFS.label, rdflib.Literal("A Sample Hub", lang="en"))
+    )
+    db_session.add(
+        Hub(
+            id=3,
+            uuid=sample_hub_uuid,
+            uri=str(sample_hub_uri),
+            data=json.loads(sample_hub_graph.serialize(format="json-ld")),
+        )
+    )
+
+    version = db_session.query(Version).where(Version.resource_id == 3).first()
+    create_embeddings(version, "hubs", vector_client)
+
+    get_response = client.get(f"/hubs/{sample_hub_uuid}/embeddings")
+    payload = get_response.json()
+
+    assert len(payload["embedding"]) == len(sample_hub_graph)
+
+
+def test_new_hub_embedding(client, db_session, vector_client):
+    sample_hub_graph = init_graph()
+    sample_hub_uuid = "a1b2c3d4-0000-0000-0000-000000000003"
+    sample_hub_uri = rdflib.URIRef(f"https://bcld.info/hubs/{sample_hub_uuid}")
+    sample_hub_graph.add((sample_hub_uri, rdflib.RDF.type, BF.Hub))
+    title_bnode = rdflib.BNode()
+    sample_hub_graph.add((sample_hub_uri, BF.title, title_bnode))
+    sample_hub_graph.add(
+        (title_bnode, BF.mainTitle, rdflib.Literal("A Great Hub", lang="en"))
+    )
+    db_session.add(
+        Hub(
+            id=4,
+            uuid=sample_hub_uuid,
+            uri=str(sample_hub_uri),
+            data=json.loads(sample_hub_graph.serialize(format="json-ld")),
+        )
+    )
+    post_result = client.post(
+        f"/hubs/{sample_hub_uuid}/embeddings", headers={"X-User": "cataloger"}
+    )
+    payload = post_result.json()
+    assert len(payload["embedding"]) == len(sample_hub_graph)
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/tests/api/test_mcp_server.py
+++ b/tests/api/test_mcp_server.py
@@ -43,5 +43,5 @@ async def test_mcp_list_tools_request(mcp_client):
 
     data = response.json()
     tools = sorted(data["result"]["tools"], key=lambda x: x["name"])
-    assert len(tools) == 23
+    assert len(tools) == 28
     assert tools[0]["name"].startswith("batch_upload")

--- a/tests/blue-core-hub.jsonld
+++ b/tests/blue-core-hub.jsonld
@@ -1,0 +1,336 @@
+[
+  {
+    "@id": "_:b19iddOtlocdOtgovresourceshubs62a26d82-4e65-c696-afed-b12d215a35b1",
+    "@type": [
+      "http://id.loc.gov/ontologies/bibframe/Identifier"
+    ],
+    "http://www.w3.org/1999/02/22-rdf-syntax-ns#value": [
+      {
+        "@value": "17955294"
+      }
+    ],
+    "http://id.loc.gov/ontologies/bibframe/qualifier": [
+      {
+        "@value": "LC-ILSDB"
+      }
+    ],
+    "http://id.loc.gov/ontologies/bibframe/source": [
+      {
+        "@id": "_:b25iddOtlocdOtgovresourceshubs62a26d82-4e65-c696-afed-b12d215a35b1"
+      }
+    ]
+  },
+  {
+    "@id": "_:b13iddOtlocdOtgovresourceshubs62a26d82-4e65-c696-afed-b12d215a35b1",
+    "@type": [
+      "http://id.loc.gov/ontologies/bibframe/VariantTitle"
+    ],
+    "http://id.loc.gov/ontologies/bibframe/mainTitle": [
+      {
+        "@language": "zxx-hang",
+        "@value": "정책 연구 시리즈"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/vocabulary/organizations/dlcmrc",
+    "@type": [
+      "http://id.loc.gov/ontologies/bibframe/Agent",
+      "http://id.loc.gov/ontologies/bibframe/Organization"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "United States, Library of Congress, Network Development and MARC Standards Office"
+      }
+    ],
+    "http://id.loc.gov/ontologies/bibframe/code": [
+      {
+        "@type": "http://id.loc.gov/datatypes/orgs/code",
+        "@value": "DLC-MRC"
+      },
+      {
+        "@type": "http://id.loc.gov/datatypes/orgs/normalized",
+        "@value": "dlcmrc"
+      },
+      {
+        "@type": "http://id.loc.gov/datatypes/orgs/iso15511",
+        "@value": "US-dlcmrc"
+      }
+    ]
+  },
+  {
+    "@id": "_:b25iddOtlocdOtgovresourceshubs62a26d82-4e65-c696-afed-b12d215a35b1",
+    "@type": [
+      "http://id.loc.gov/ontologies/bibframe/Source"
+    ],
+    "http://id.loc.gov/ontologies/bibframe/code": [
+      {
+        "@value": "local"
+      }
+    ]
+  },
+  {
+    "@id": "_:b37iddOtlocdOtgovresourceshubs62a26d82-4e65-c696-afed-b12d215a35b1",
+    "@type": [
+      "http://id.loc.gov/ontologies/bibframe/AdminMetadata"
+    ],
+    "http://id.loc.gov/ontologies/bibframe/status": [
+      {
+        "@id": "http://id.loc.gov/vocabulary/mstatus/n"
+      }
+    ],
+    "http://id.loc.gov/ontologies/bibframe/date": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#date",
+        "@value": "2013-11-26"
+      }
+    ]
+  },
+  {
+    "@id": "_:b29iddOtlocdOtgovresourceshubs62a26d82-4e65-c696-afed-b12d215a35b1",
+    "@type": [
+      "http://id.loc.gov/ontologies/bibframe/Note",
+      "http://id.loc.gov/vocabulary/mnotetype/descsource"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "Created from bib ap."
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/vocabulary/menclvl/7",
+    "@type": [
+      "http://id.loc.gov/ontologies/bflc/EncodingLevel"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "minimal"
+      }
+    ],
+    "http://id.loc.gov/ontologies/bibframe/code": [
+      {
+        "@value": "7"
+      }
+    ]
+  },
+  {
+    "@id": "_:b88iddOtlocdOtgovresourceshubs62a26d82-4e65-c696-afed-b12d215a35b1",
+    "@type": [
+      "http://id.loc.gov/ontologies/bibframe/Local"
+    ],
+    "http://www.w3.org/1999/02/22-rdf-syntax-ns#value": [
+      {
+        "@value": "62a26d82-4e65-c696-afed-b12d215a35b1"
+      }
+    ],
+    "http://id.loc.gov/ontologies/bibframe/assigner": [
+      {
+        "@id": "http://id.loc.gov/vocabulary/organizations/dlc"
+      }
+    ]
+  },
+  {
+    "@id": "_:b47iddOtlocdOtgovresourceshubs62a26d82-4e65-c696-afed-b12d215a35b1",
+    "@type": [
+      "http://id.loc.gov/ontologies/bibframe/AdminMetadata"
+    ],
+    "http://id.loc.gov/ontologies/bibframe/status": [
+      {
+        "@id": "http://id.loc.gov/vocabulary/mstatus/c"
+      }
+    ],
+    "http://id.loc.gov/ontologies/bibframe/date": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "@value": "2018-02-20T13:27:21"
+      }
+    ]
+  },
+  {
+    "@id": "_:b9iddOtlocdOtgovresourceshubs62a26d82-4e65-c696-afed-b12d215a35b1",
+    "@type": [
+      "http://id.loc.gov/ontologies/bibframe/Title"
+    ],
+    "http://id.loc.gov/ontologies/bibframe/mainTitle": [
+      {
+        "@value": "Chŏngch'aek yŏn'gu sirijŭ"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/vocabulary/mstatus/c",
+    "@type": [
+      "http://id.loc.gov/ontologies/bibframe/Status",
+      "http://id.loc.gov/ontologies/bibframe/Status"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "changed"
+      },
+      {
+        "@value": "changed"
+      }
+    ],
+    "http://id.loc.gov/ontologies/bibframe/code": [
+      {
+        "@value": "c"
+      },
+      {
+        "@value": "c"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/vocabulary/organizations/dlc",
+    "@type": [
+      "http://id.loc.gov/ontologies/bibframe/Organization"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "United States, Library of Congress"
+      }
+    ],
+    "http://id.loc.gov/ontologies/bibframe/code": [
+      {
+        "@type": "http://id.loc.gov/datatypes/orgs/code",
+        "@value": "DLC"
+      },
+      {
+        "@type": "http://id.loc.gov/datatypes/orgs/normalized",
+        "@value": "dlc"
+      },
+      {
+        "@type": "http://id.loc.gov/datatypes/orgs/iso15511",
+        "@value": "US-dlc"
+      }
+    ]
+  },
+  {
+    "@id": "_:b57iddOtlocdOtgovresourceshubs62a26d82-4e65-c696-afed-b12d215a35b1",
+    "@type": [
+      "http://id.loc.gov/ontologies/bibframe/AdminMetadata"
+    ],
+    "http://id.loc.gov/ontologies/bibframe/status": [
+      {
+        "@id": "http://id.loc.gov/vocabulary/mstatus/c"
+      }
+    ],
+    "http://id.loc.gov/ontologies/bibframe/agent": [
+      {
+        "@id": "http://id.loc.gov/vocabulary/organizations/dlcmrc"
+      }
+    ],
+    "http://id.loc.gov/ontologies/bibframe/generationProcess": [
+      {
+        "@id": "https://github.com/lcnetdev/marc2bibframe2/tree/v2.10-dev"
+      }
+    ],
+    "http://id.loc.gov/ontologies/bibframe/date": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "@value": "2025-04-25T07:18:10.274737-04:00"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/resources/hubs/62a26d82-4e65-c696-afed-b12d215a35b1",
+    "@type": [
+      "http://id.loc.gov/ontologies/bibframe/Work",
+      "http://id.loc.gov/ontologies/bibframe/Hub"
+    ],
+    "http://id.loc.gov/ontologies/bflc/aap": [
+      {
+        "@value": "Chŏngch'aek yŏn'gu sirijŭ"
+      }
+    ],
+    "http://id.loc.gov/ontologies/bflc/aap-normalized": [
+      {
+        "@value": "chŏngch'aekyŏn'gusirijŭ"
+      }
+    ],
+    "http://id.loc.gov/ontologies/bibframe/title": [
+      {
+        "@id": "_:b9iddOtlocdOtgovresourceshubs62a26d82-4e65-c696-afed-b12d215a35b1"
+      },
+      {
+        "@id": "_:b13iddOtlocdOtgovresourceshubs62a26d82-4e65-c696-afed-b12d215a35b1"
+      }
+    ],
+    "http://id.loc.gov/ontologies/bflc/marcKey": [
+      {
+        "@value": "1300 $aChŏngch'aek yŏn'gu sirijŭ ;"
+      },
+      {
+        "@language": "zxx-hang",
+        "@value": "1300 $a정책 연구 시리즈"
+      }
+    ],
+    "http://id.loc.gov/ontologies/bibframe/identifiedBy": [
+      {
+        "@id": "_:b19iddOtlocdOtgovresourceshubs62a26d82-4e65-c696-afed-b12d215a35b1"
+      }
+    ],
+    "http://id.loc.gov/ontologies/bibframe/note": [
+      {
+        "@id": "_:b29iddOtlocdOtgovresourceshubs62a26d82-4e65-c696-afed-b12d215a35b1"
+      }
+    ],
+    "http://purl.org/dc/terms/isPartOf": [
+      {
+        "@id": "http://id.loc.gov/resources/hubs"
+      }
+    ],
+    "http://id.loc.gov/ontologies/bibframe/adminMetadata": [
+      {
+        "@id": "_:b37iddOtlocdOtgovresourceshubs62a26d82-4e65-c696-afed-b12d215a35b1"
+      },
+      {
+        "@id": "_:b47iddOtlocdOtgovresourceshubs62a26d82-4e65-c696-afed-b12d215a35b1"
+      },
+      {
+        "@id": "_:b57iddOtlocdOtgovresourceshubs62a26d82-4e65-c696-afed-b12d215a35b1"
+      },
+      {
+        "@id": "_:b79iddOtlocdOtgovresourceshubs62a26d82-4e65-c696-afed-b12d215a35b1"
+      }
+    ]
+  },
+  {
+    "@id": "_:b79iddOtlocdOtgovresourceshubs62a26d82-4e65-c696-afed-b12d215a35b1",
+    "@type": [
+      "http://id.loc.gov/ontologies/bibframe/AdminMetadata"
+    ],
+    "http://id.loc.gov/ontologies/bibframe/descriptionLevel": [
+      {
+        "@id": "http://id.loc.gov/ontologies/bibframe-2-5-0/"
+      }
+    ],
+    "http://id.loc.gov/ontologies/bflc/encodingLevel": [
+      {
+        "@id": "http://id.loc.gov/vocabulary/menclvl/7"
+      }
+    ],
+    "http://id.loc.gov/ontologies/bibframe/identifiedBy": [
+      {
+        "@id": "_:b88iddOtlocdOtgovresourceshubs62a26d82-4e65-c696-afed-b12d215a35b1"
+      }
+    ]
+  },
+  {
+    "@id": "http://id.loc.gov/vocabulary/mstatus/n",
+    "@type": [
+      "http://id.loc.gov/ontologies/bibframe/Status"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@value": "new"
+      }
+    ],
+    "http://id.loc.gov/ontologies/bibframe/code": [
+      {
+        "@value": "n"
+      }
+    ]
+  }
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ from bluecore_models.models import (
     Base,
     BibframeClass,
     BibframeOtherResources,
+    Hub,
     Instance,
     OtherResource,
     ResourceBase,
@@ -137,6 +138,7 @@ def client(mocker, db_session, app):
             ResourceBase.__table__,
             BibframeClass.__table__,
             BibframeOtherResources.__table__,
+            Hub.__table__,
             Instance.__table__,
             OtherResource.__table__,
             ResourceBibframeClass.__table__,
@@ -173,5 +175,6 @@ def vector_client():
     yield client
 
     # on tear down empty collections for the next tests
+    client.delete(collection_name="hubs", filter="version == 1")
     client.delete(collection_name="instances", filter="version == 1")
     client.delete(collection_name="works", filter="version == 1")

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
@@ -81,7 +81,7 @@ wheels = [
 
 [[package]]
 name = "bluecore-api"
-version = "0.17.1"
+version = "0.18.1"
 source = { editable = "." }
 dependencies = [
     { name = "bluecore-models" },
@@ -115,7 +115,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bluecore-models", specifier = ">=0.12.0" },
+    { name = "bluecore-models", specifier = ">=0.14.0" },
     { name = "fastapi", extras = ["standard"] },
     { name = "fastapi-keycloak-middleware", specifier = ">=1.2.0" },
     { name = "fastapi-mcp", specifier = ">=0.4.0" },
@@ -146,7 +146,7 @@ dev = [
 
 [[package]]
 name = "bluecore-models"
-version = "0.12.0"
+version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "alembic" },
@@ -154,11 +154,12 @@ dependencies = [
     { name = "pyld" },
     { name = "pymilvus", extra = ["milvus-lite", "model"] },
     { name = "rdflib" },
+    { name = "tenacity" },
     { name = "transformers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/50/19/9367f71d314ea6aeaae58723ab8273de52555658e8d884e093273f233ecf/bluecore_models-0.12.0.tar.gz", hash = "sha256:38aa6b7118353b8efe323d901fb883d90715ab01b2b2773722d6f2081e53ed74", size = 48380, upload-time = "2026-04-23T15:39:20.111Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/1d/786aa70b5641667d5edfe40d339b4823a35f1dd5d0b9ca1e406775ce9739/bluecore_models-0.14.0.tar.gz", hash = "sha256:98aa52425c175560a4fbb09ed506e29564355d0ecef14e38db339ca85a93a9d5", size = 165055, upload-time = "2026-06-16T19:36:41.07Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/1b/19360436d5ae3cb96b054de55ba995f3a2eede17e2263df39e20fc21f87d/bluecore_models-0.12.0-py3-none-any.whl", hash = "sha256:5732113cfff3438a80029802e0e3eef5c6477c5458259b4eb5cf47c824a4a20c", size = 29046, upload-time = "2026-04-23T15:39:19.211Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/66/dfad066ada7924dc8536adacd18736c2bf45f54a1dfbc6c78759fcd26e19/bluecore_models-0.14.0-py3-none-any.whl", hash = "sha256:94b7ee501e2d6c73185d30626ba8db5988806d27a7240d4b1d6c20d2947fa746", size = 31013, upload-time = "2026-06-16T19:36:40.109Z" },
 ]
 
 [[package]]
@@ -568,7 +569,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
     { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
-    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
     { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
@@ -579,7 +579,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
     { url = "https://files.pythonhosted.org/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
     { url = "https://files.pythonhosted.org/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
@@ -590,7 +589,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
     { url = "https://files.pythonhosted.org/packages/c0/aa/687d6b12ffb505a4447567d1f3abea23bd20e73a5bed63871178e0831b7a/greenlet-3.2.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c17b6b34111ea72fc5a4e4beec9711d2226285f0386ea83477cbb97c30a3f3a5", size = 699218, upload-time = "2025-08-07T13:45:30.969Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
     { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },
@@ -2204,6 +2202,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why was this change made?
Add Hub resource API endpoints (Fix #214)

- New GET /hubs/{hub_uuid} endpoint with optional ?expand=true for expanded graph data
- New POST /hubs/ endpoint to create a Hub from JSON-LD input
- New PUT /hubs/{hub_uuid} endpoint to update Hub data
- New GET /hubs/{hub_uuid}/embeddings and POST /hubs/{hub_uuid}/embeddings endpoints for vector embeddings
- Added HubCreateSchema, HubUpdateSchema, HubSchema, and HubEmbeddingSchema Pydantic schemas
- Registered hub router in main.py
- Full test coverage including create, read, expand, and embedding tests with a sample Hub JSON-LD fixture
- Bumps pyproject version to 0.18.0 and bluecore-models dependency to 0.14.1
- Ignore keycloak auth for hub GETs

## How was this change tested?
- new file:   tests/api/test_hub.py
- new file:   tests/blue-core-hub.jsonld
- modified:   tests/conftest.py

With `pyproject.toml` using [local branch](https://github.com/blue-core-lod/bluecore-models/tree/80-bibframe-hubs) of bluecore-models:
```
[tool.uv.sources]
bluecore-models = { path = "../../bluecore-models", editable = true }
```

Waiting for https://github.com/blue-core-lod/bluecore-models/pull/93 for tests to pass.

## Which documentation and/or configurations were updated?
N/A