### PR TITLE
Allow content negotiation for application/json too

### DIFF
--- a/src/bluecore_api/app/routes/search.py
+++ b/src/bluecore_api/app/routes/search.py
@@ -144,7 +144,7 @@ async def search(
     type: SearchType = SearchType.ALL,
 ) -> dict[str, Any]:
     """
-    Search for Works ans Instances.
+    Search for Works and Instances.
     It transforms the query string to be compatible with PostgreSQL full-text search.
     It supports phrase search using double quotes.
     If the query contains a phrase in double quotes, it will use "simple" language for

--- a/src/bluecore_api/app/utils/serializer.py
+++ b/src/bluecore_api/app/utils/serializer.py
@@ -18,6 +18,7 @@ type SerializerFn = Callable[[Instance | Work, bool], Response | None]
 serializer_format_registry: dict[str, SerializerFn] = {
     "cbd.jsonld": as_cbd_jsonld,
     "cbd.xml": as_cbd_xml,
+    "json": as_jsonld,
     "jsonld": as_jsonld,
     "nt": as_ntriples,
     "rdf": as_rdfxml,
@@ -28,6 +29,7 @@ serializer_format_registry: dict[str, SerializerFn] = {
 serializer_accept_registry: dict[str, SerializerFn] = {
     "application/cbd+jsonld": as_cbd_jsonld,
     "application/cbd+xml": as_cbd_xml,
+    "application/json": as_jsonld,
     "application/ld+json": as_jsonld,
     "application/n-triples": as_ntriples,
     "application/rdf+xml": as_rdfxml,

--- a/tests/api/test_instance.py
+++ b/tests/api/test_instance.py
@@ -117,6 +117,20 @@ def test_get_instance_jsonld(client, db_session):
     assert response.json()["@id"] == test_instance_bluecore_uri
 
 
+def test_get_instance_json(client, db_session):
+    add_test_instance(db_session)
+
+    response = client.get(
+        f"/instances/{test_instance_uuid}", headers={"Accept": "application/json"}
+    )
+    assert response.status_code == 200
+    assert response.json()["@id"] == test_instance_bluecore_uri
+
+    response = client.get(f"/instances/{test_instance_uuid}.jsonld")
+    assert response.status_code == 200
+    assert response.json()["@id"] == test_instance_bluecore_uri
+
+
 def test_get_instance_rdf_xml(client, db_session):
     add_test_instance(db_session)
 

--- a/tests/api/test_work.py
+++ b/tests/api/test_work.py
@@ -73,6 +73,23 @@ def test_get_work_vnd_sinopia_json(client, db_session):
     assert len(fetched_graph) == len(orig_graph)
 
 
+def test_get_work_json(client, db_session):
+    # Note: since we are setting the JSON-LD data directly here on the Work model the
+    # URI needs to match whats in the JSON-LD file or else the JSON-LD
+    # framing will result in an empty graph.
+    add_test_work(db_session)
+
+    response = client.get(
+        f"/works/{test_work_uuid}", headers={"Accept": "application/json"}
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    fetched_graph = load_jsonld(data)
+    assert len(fetched_graph) == len(orig_graph)
+
+
 def test_get_expanded_work(client, db_session):
     add_test_expanded_work(db_session)
 


### PR DESCRIPTION
## Why was this change made?

If someone asks for JSON we can give them the JSON-LD, which is valid
JSON too.

## How was this change tested?

unit tests

## Which documentation and/or configurations were updated?

n/a




