### PR TITLE
Use save_graph() in PUT/POST routes for consistent RDF persistence

### DIFF
--- a/src/bluecore_api/app/routes/hubs.py
+++ b/src/bluecore_api/app/routes/hubs.py
@@ -1,18 +1,14 @@
+import json
 import os
-
-import rdflib
-from rdflib import RDF
 
 from bluecore_models.bluecore_graph import save_graph
 from bluecore_models.models import Hub
-from bluecore_models.utils.graph import BF
+from bluecore_models.utils.graph import BF, load_jsonld
 from bluecore_models.utils.vector_db import create_embeddings
-
-from pymilvus import MilvusClient
-
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi_keycloak_middleware import CheckPermissions
-
+from pymilvus import MilvusClient
+from rdflib import RDF
 from sqlalchemy.orm import Session
 
 from bluecore_api.database import (
@@ -21,13 +17,13 @@ from bluecore_api.database import (
     get_session_maker,
     get_vector_client,
 )
+from bluecore_api.expansion import expand_resource_graph
 from bluecore_api.schemas.schemas import (
     HubCreateSchema,
     HubEmbeddingSchema,
     HubSchema,
     HubUpdateSchema,
 )
-from bluecore_api.expansion import expand_resource_graph
 
 endpoints = APIRouter()
 
@@ -84,8 +80,7 @@ async def create_hub(
     db: Session = Depends(get_db),
     session_maker=Depends(get_session_maker),
 ):
-    graph = rdflib.Graph()
-    graph.parse(data=hub.data, format="json-ld")
+    graph = load_jsonld(json.loads(hub.data))
     result_graph = save_graph(session_maker, graph, BLUECORE_URL)
     hub_uri = str(next(result_graph.subjects(RDF.type, BF.Hub)))
     return db.query(Hub).filter(Hub.uri == hub_uri).first()
@@ -108,8 +103,7 @@ async def update_hub(
         raise HTTPException(status_code=404, detail=f"Hub {hub_uuid} not found")
 
     if hub.data is not None:
-        graph = rdflib.Graph()
-        graph.parse(data=hub.data, format="json-ld")
+        graph = load_jsonld(json.loads(hub.data))
         save_graph(session_maker, graph, BLUECORE_URL)
         db.refresh(db_hub)
 

--- a/src/bluecore_api/app/routes/hubs.py
+++ b/src/bluecore_api/app/routes/hubs.py
@@ -1,7 +1,12 @@
 import os
-import json
 
-from datetime import datetime, UTC
+import rdflib
+from rdflib import RDF
+
+from bluecore_models.bluecore_graph import save_graph
+from bluecore_models.models import Hub
+from bluecore_models.utils.graph import BF
+from bluecore_models.utils.vector_db import create_embeddings
 
 from pymilvus import MilvusClient
 
@@ -10,11 +15,12 @@ from fastapi_keycloak_middleware import CheckPermissions
 
 from sqlalchemy.orm import Session
 
-from bluecore_models.models import Hub
-from bluecore_models.utils.graph import handle_external_subject
-from bluecore_models.utils.vector_db import create_embeddings
-
-from bluecore_api.database import filter_vector_result, get_db, get_vector_client
+from bluecore_api.database import (
+    filter_vector_result,
+    get_db,
+    get_session_maker,
+    get_vector_client,
+)
 from bluecore_api.schemas.schemas import (
     HubCreateSchema,
     HubEmbeddingSchema,
@@ -73,22 +79,16 @@ async def get_embedding(
     status_code=201,
     operation_id="create_hub",
 )
-async def create_hub(hub: HubCreateSchema, db: Session = Depends(get_db)):
-    time_now = datetime.now(UTC)
-    updated_payload = handle_external_subject(
-        data=hub.data, type="hubs", bluecore_base_url=BLUECORE_URL
-    )
-    db_hub = Hub(
-        uri=updated_payload.get("uri"),
-        data=updated_payload.get("data"),
-        uuid=updated_payload.get("uuid"),
-        created_at=time_now,
-        updated_at=time_now,
-    )
-    db.add(db_hub)
-    db.commit()
-    db.refresh(db_hub)
-    return db_hub
+async def create_hub(
+    hub: HubCreateSchema,
+    db: Session = Depends(get_db),
+    session_maker=Depends(get_session_maker),
+):
+    graph = rdflib.Graph()
+    graph.parse(data=hub.data, format="json-ld")
+    result_graph = save_graph(session_maker, graph, BLUECORE_URL)
+    hub_uri = str(next(result_graph.subjects(RDF.type, BF.Hub)))
+    return db.query(Hub).filter(Hub.uri == hub_uri).first()
 
 
 @endpoints.put(
@@ -98,17 +98,21 @@ async def create_hub(hub: HubCreateSchema, db: Session = Depends(get_db)):
     operation_id="update_hub",
 )
 async def update_hub(
-    hub_uuid: str, hub: HubUpdateSchema, db: Session = Depends(get_db)
+    hub_uuid: str,
+    hub: HubUpdateSchema,
+    db: Session = Depends(get_db),
+    session_maker=Depends(get_session_maker),
 ):
     db_hub = db.query(Hub).filter(Hub.uuid == hub_uuid).first()
     if db_hub is None:
         raise HTTPException(status_code=404, detail=f"Hub {hub_uuid} not found")
 
     if hub.data is not None:
-        db_hub.data = json.loads(hub.data)
+        graph = rdflib.Graph()
+        graph.parse(data=hub.data, format="json-ld")
+        save_graph(session_maker, graph, BLUECORE_URL)
+        db.refresh(db_hub)
 
-    db.commit()
-    db.refresh(db_hub)
     return db_hub
 
 

--- a/src/bluecore_api/app/routes/instances.py
+++ b/src/bluecore_api/app/routes/instances.py
@@ -2,16 +2,14 @@ import json
 import os
 from pathlib import Path
 
-import rdflib
-from rdflib import RDF, URIRef
-
 from bluecore_models.bluecore_graph import save_graph
 from bluecore_models.models import Instance, Work
-from bluecore_models.utils.graph import BF
+from bluecore_models.utils.graph import BF, load_jsonld
 from bluecore_models.utils.vector_db import create_embeddings
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi_keycloak_middleware import CheckPermissions
 from pymilvus import MilvusClient
+from rdflib import RDF, URIRef
 from sqlalchemy.orm import Session
 
 from bluecore_api.app.utils.serialize.response_generator import as_html
@@ -104,17 +102,14 @@ async def create_instance(
     db: Session = Depends(get_db),
     session_maker=Depends(get_session_maker),
 ):
-    graph = rdflib.Graph()
-    graph.parse(data=instance.data, format="json-ld")
+    graph = load_jsonld(json.loads(instance.data))
     if instance.work_id is not None:
         db_work = db.query(Work).filter(Work.id == instance.work_id).first()
         if db_work is None:
             raise HTTPException(
                 status_code=404, detail=f"Work {instance.work_id} not found"
             )
-        work_graph = rdflib.Graph()
-        work_graph.parse(data=json.dumps(db_work.data), format="json-ld")
-        graph += work_graph
+        graph += load_jsonld(db_work.data)
         instance_subject = next(graph.subjects(RDF.type, BF.Instance))
         graph.add((instance_subject, BF.instanceOf, URIRef(db_work.uri)))
     result_graph = save_graph(session_maker, graph, BLUECORE_URL)
@@ -141,17 +136,14 @@ async def update_instance(
         )
 
     if instance.data is not None:
-        graph = rdflib.Graph()
-        graph.parse(data=instance.data, format="json-ld")
+        graph = load_jsonld(json.loads(instance.data))
         if instance.work_id is not None:
             db_work = db.query(Work).filter(Work.id == instance.work_id).first()
             if db_work is None:
                 raise HTTPException(
                     status_code=404, detail=f"Work {instance.work_id} not found"
                 )
-            work_graph = rdflib.Graph()
-            work_graph.parse(data=json.dumps(db_work.data), format="json-ld")
-            graph += work_graph
+            graph += load_jsonld(db_work.data)
             instance_subject = next(graph.subjects(RDF.type, BF.Instance))
             graph.add((instance_subject, BF.instanceOf, URIRef(db_work.uri)))
         save_graph(session_maker, graph, BLUECORE_URL)

--- a/src/bluecore_api/app/routes/instances.py
+++ b/src/bluecore_api/app/routes/instances.py
@@ -1,10 +1,13 @@
 import json
 import os
-from datetime import UTC, datetime
 from pathlib import Path
 
-from bluecore_models.models import Instance
-from bluecore_models.utils.graph import handle_external_subject
+import rdflib
+from rdflib import RDF, URIRef
+
+from bluecore_models.bluecore_graph import save_graph
+from bluecore_models.models import Instance, Work
+from bluecore_models.utils.graph import BF
 from bluecore_models.utils.vector_db import create_embeddings
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi_keycloak_middleware import CheckPermissions
@@ -15,7 +18,12 @@ from bluecore_api.app.utils.serialize.response_generator import as_html
 from bluecore_api.app.utils.serializer import (
     serialize,
 )
-from bluecore_api.database import filter_vector_result, get_db, get_vector_client
+from bluecore_api.database import (
+    filter_vector_result,
+    get_db,
+    get_session_maker,
+    get_vector_client,
+)
 from bluecore_api.schemas.schemas import (
     InstanceCreateSchema,
     InstanceEmbeddingSchema,
@@ -92,24 +100,26 @@ async def get_embedding(
     operation_id="new_instance",
 )
 async def create_instance(
-    instance: InstanceCreateSchema, db: Session = Depends(get_db)
+    instance: InstanceCreateSchema,
+    db: Session = Depends(get_db),
+    session_maker=Depends(get_session_maker),
 ):
-    time_now = datetime.now(UTC)
-    updated_payload = handle_external_subject(
-        data=instance.data, type="instances", bluecore_base_url=BLUECORE_URL
-    )
-    db_instance = Instance(
-        uri=updated_payload.get("uri"),
-        data=updated_payload.get("data"),
-        work_id=instance.work_id,
-        uuid=updated_payload.get("uuid"),
-        created_at=time_now,
-        updated_at=time_now,
-    )
-    db.add(db_instance)
-    db.commit()
-    db.refresh(db_instance)
-    return db_instance
+    graph = rdflib.Graph()
+    graph.parse(data=instance.data, format="json-ld")
+    if instance.work_id is not None:
+        db_work = db.query(Work).filter(Work.id == instance.work_id).first()
+        if db_work is None:
+            raise HTTPException(
+                status_code=404, detail=f"Work {instance.work_id} not found"
+            )
+        work_graph = rdflib.Graph()
+        work_graph.parse(data=json.dumps(db_work.data), format="json-ld")
+        graph += work_graph
+        instance_subject = next(graph.subjects(RDF.type, BF.Instance))
+        graph.add((instance_subject, BF.instanceOf, URIRef(db_work.uri)))
+    result_graph = save_graph(session_maker, graph, BLUECORE_URL)
+    instance_uri = str(next(result_graph.subjects(RDF.type, BF.Instance)))
+    return db.query(Instance).filter(Instance.uri == instance_uri).first()
 
 
 @endpoints.put(
@@ -119,7 +129,10 @@ async def create_instance(
     operation_id="update_instance",
 )
 async def update_instance(
-    instance_uuid: str, instance: InstanceUpdateSchema, db: Session = Depends(get_db)
+    instance_uuid: str,
+    instance: InstanceUpdateSchema,
+    db: Session = Depends(get_db),
+    session_maker=Depends(get_session_maker),
 ):
     db_instance = db.query(Instance).filter(Instance.uuid == instance_uuid).first()
     if db_instance is None:
@@ -127,15 +140,23 @@ async def update_instance(
             status_code=404, detail=f"Instance {instance_uuid} not found"
         )
 
-    # Update fields if they are provided
     if instance.data is not None:
-        # TODO: should instance.data be a dict instead of a JSON str?
-        db_instance.data = json.loads(instance.data)
-    if instance.work_id is not None:
-        db_instance.work_id = instance.work_id
+        graph = rdflib.Graph()
+        graph.parse(data=instance.data, format="json-ld")
+        if instance.work_id is not None:
+            db_work = db.query(Work).filter(Work.id == instance.work_id).first()
+            if db_work is None:
+                raise HTTPException(
+                    status_code=404, detail=f"Work {instance.work_id} not found"
+                )
+            work_graph = rdflib.Graph()
+            work_graph.parse(data=json.dumps(db_work.data), format="json-ld")
+            graph += work_graph
+            instance_subject = next(graph.subjects(RDF.type, BF.Instance))
+            graph.add((instance_subject, BF.instanceOf, URIRef(db_work.uri)))
+        save_graph(session_maker, graph, BLUECORE_URL)
+        db.refresh(db_instance)
 
-    db.commit()
-    db.refresh(db_instance)
     return db_instance
 
 

--- a/src/bluecore_api/app/routes/works.py
+++ b/src/bluecore_api/app/routes/works.py
@@ -1,16 +1,15 @@
+import json
 import os
 from pathlib import Path
 
-import rdflib
-from rdflib import RDF
-
 from bluecore_models.bluecore_graph import save_graph
 from bluecore_models.models import Work
-from bluecore_models.utils.graph import BF
+from bluecore_models.utils.graph import BF, load_jsonld
 from bluecore_models.utils.vector_db import create_embeddings
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi_keycloak_middleware import CheckPermissions
 from pymilvus import MilvusClient
+from rdflib import RDF
 from sqlalchemy.orm import Session
 
 from bluecore_api.app.utils.serialize.response_generator import as_html
@@ -95,8 +94,7 @@ async def create_work(
     db: Session = Depends(get_db),
     session_maker=Depends(get_session_maker),
 ):
-    graph = rdflib.Graph()
-    graph.parse(data=work.data, format="json-ld")
+    graph = load_jsonld(json.loads(work.data))
     result_graph = save_graph(session_maker, graph, BLUECORE_URL)
     work_uri = str(next(result_graph.subjects(RDF.type, BF.Work)))
     return db.query(Work).filter(Work.uri == work_uri).first()
@@ -119,8 +117,7 @@ async def update_work(
         raise HTTPException(status_code=404, detail=f"Work {work_uuid} not found")
 
     if work.data is not None:
-        graph = rdflib.Graph()
-        graph.parse(data=work.data, format="json-ld")
+        graph = load_jsonld(json.loads(work.data))
         save_graph(session_maker, graph, BLUECORE_URL)
         db.refresh(db_work)
 

--- a/src/bluecore_api/app/routes/works.py
+++ b/src/bluecore_api/app/routes/works.py
@@ -1,10 +1,12 @@
-import json
 import os
-from datetime import UTC, datetime
 from pathlib import Path
 
+import rdflib
+from rdflib import RDF
+
+from bluecore_models.bluecore_graph import save_graph
 from bluecore_models.models import Work
-from bluecore_models.utils.graph import handle_external_subject
+from bluecore_models.utils.graph import BF
 from bluecore_models.utils.vector_db import create_embeddings
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi_keycloak_middleware import CheckPermissions
@@ -13,7 +15,12 @@ from sqlalchemy.orm import Session
 
 from bluecore_api.app.utils.serialize.response_generator import as_html
 from bluecore_api.app.utils.serializer import serialize
-from bluecore_api.database import filter_vector_result, get_db, get_vector_client
+from bluecore_api.database import (
+    filter_vector_result,
+    get_db,
+    get_session_maker,
+    get_vector_client,
+)
 from bluecore_api.schemas.schemas import (
     WorkCreateSchema,
     WorkEmbeddingSchema,
@@ -83,22 +90,16 @@ async def get_embedding(
     status_code=201,
     operation_id="get_works",
 )
-async def create_work(work: WorkCreateSchema, db: Session = Depends(get_db)):
-    time_now = datetime.now(UTC)
-    updated_payload = handle_external_subject(
-        data=work.data, type="works", bluecore_base_url=BLUECORE_URL
-    )
-    db_work = Work(
-        uri=updated_payload.get("uri"),
-        data=updated_payload.get("data"),
-        uuid=updated_payload.get("uuid"),
-        created_at=time_now,
-        updated_at=time_now,
-    )
-    db.add(db_work)
-    db.commit()
-    db.refresh(db_work)
-    return db_work
+async def create_work(
+    work: WorkCreateSchema,
+    db: Session = Depends(get_db),
+    session_maker=Depends(get_session_maker),
+):
+    graph = rdflib.Graph()
+    graph.parse(data=work.data, format="json-ld")
+    result_graph = save_graph(session_maker, graph, BLUECORE_URL)
+    work_uri = str(next(result_graph.subjects(RDF.type, BF.Work)))
+    return db.query(Work).filter(Work.uri == work_uri).first()
 
 
 @endpoints.put(
@@ -108,19 +109,21 @@ async def create_work(work: WorkCreateSchema, db: Session = Depends(get_db)):
     operation_id="update_work",
 )
 async def update_work(
-    work_uuid: str, work: WorkUpdateSchema, db: Session = Depends(get_db)
+    work_uuid: str,
+    work: WorkUpdateSchema,
+    db: Session = Depends(get_db),
+    session_maker=Depends(get_session_maker),
 ):
     db_work = db.query(Work).filter(Work.uuid == work_uuid).first()
     if db_work is None:
         raise HTTPException(status_code=404, detail=f"Work {work_uuid} not found")
 
-    # Update data if it is provided
     if work.data is not None:
-        # TODO: some day it would be nice to not have to parse work.data as JSON
-        db_work.data = json.loads(work.data)
+        graph = rdflib.Graph()
+        graph.parse(data=work.data, format="json-ld")
+        save_graph(session_maker, graph, BLUECORE_URL)
+        db.refresh(db_work)
 
-    db.commit()
-    db.refresh(db_work)
     return db_work
 
 

--- a/src/bluecore_api/database.py
+++ b/src/bluecore_api/database.py
@@ -20,6 +20,10 @@ def get_db():
         db.close()
 
 
+def get_session_maker():
+    return Session
+
+
 def get_vector_client():
     if not milvus_url:
         client = MilvusClient("test-vector.db")  # For testing

--- a/tests/api/test_instance.py
+++ b/tests/api/test_instance.py
@@ -234,21 +234,21 @@ def test_create_instance(client):
 
 
 def test_update_instance(client, db_session):
+    create_response = client.post(
+        "/instances/",
+        headers={"X-User": "cataloger"},
+        json={
+            "data": pathlib.Path("tests/blue-core-instance.jsonld").read_text(),
+            "work_id": None,
+        },
+    )
+    assert create_response.status_code == 201
+
+    instance_uri = rdflib.URIRef(create_response.json()["uri"])
+    instance_uuid = create_response.json()["uri"].split("/")[-1]
     instance_graph = init_graph()
     instance_graph.parse(
-        data=pathlib.Path("tests/blue-core-instance.jsonld").read_text(),
-        format="json-ld",
-    )
-    instance_uri = rdflib.URIRef(
-        "https://bcld.info/instances/75d831b9-e0d6-40f0-abb3-e9130622eb8a"
-    )
-    db_session.add(
-        Instance(
-            id=2,
-            uuid="75d831b9-e0d6-40f0-abb3-e9130622eb8a",
-            uri=str(instance_uri),
-            data=json.loads(instance_graph.serialize(format="json-ld")),
-        )
+        data=json.dumps(create_response.json()["data"]), format="json-ld"
     )
 
     # Updates Graph
@@ -260,19 +260,17 @@ def test_update_instance(client, db_session):
     )
 
     put_response = client.put(
-        "/instances/75d831b9-e0d6-40f0-abb3-e9130622eb8a",
+        f"/instances/{instance_uuid}",
         headers={"X-User": "cataloger"},
         json={"data": instance_graph.serialize(format="json-ld")},
     )
     assert put_response.status_code == 200
 
     # Retrieve Instance
-    get_response = client.get(
-        "/instances/75d831b9-e0d6-40f0-abb3-e9130622eb8a.vnd.sinopia.json"
-    )
+    get_response = client.get(f"/instances/{instance_uuid}.vnd.sinopia.json")
     payload = get_response.json()
     new_instance_graph = init_graph()
-    new_instance_graph.parse(data=payload["data"], format="json-ld")
+    new_instance_graph.parse(data=json.dumps(payload["data"]), format="json-ld")
     oclc_number = new_instance_graph.value(
         predicate=rdflib.RDF.type, object=BF.OclcNumber
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,8 @@ from fastapi.testclient import TestClient
 from fastapi_keycloak_middleware import get_auth, get_user
 from httpx import ASGITransport, AsyncClient
 
+from contextlib import contextmanager
+
 from pymilvus import MilvusClient
 
 from bluecore_models.models import (
@@ -147,7 +149,7 @@ def client(mocker, db_session, app):
         ],
     )
 
-    from bluecore_api.database import get_db
+    from bluecore_api.database import get_db, get_session_maker
 
     def override_get_db():
         db = db_session
@@ -156,7 +158,20 @@ def client(mocker, db_session, app):
         finally:
             db.close()
 
+    # save_graph() manages its own session via session_maker(). We override it
+    # here to use the existing db_session instead of opening a second connection,
+    # which would deadlock when db_session holds uncommitted rows that
+    # save_graph() tries to write. @contextmanager wraps db_session so it can
+    # be used as a context manager by save_graph().
+    def override_get_session_maker():
+        @contextmanager
+        def use_existing_session():
+            yield db_session
+
+        return use_existing_session
+
     app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_session_maker] = override_get_session_maker
 
     with TestClient(app) as c:
         yield c

--- a/uv.lock
+++ b/uv.lock
@@ -115,7 +115,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bluecore-models", specifier = ">=0.14.0" },
+    { name = "bluecore-models", specifier = ">=0.14.1" },
     { name = "fastapi", extras = ["standard"] },
     { name = "fastapi-keycloak-middleware", specifier = ">=1.2.0" },
     { name = "fastapi-mcp", specifier = ">=0.4.0" },
@@ -146,7 +146,7 @@ dev = [
 
 [[package]]
 name = "bluecore-models"
-version = "0.14.0"
+version = "0.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "alembic" },
@@ -157,9 +157,9 @@ dependencies = [
     { name = "tenacity" },
     { name = "transformers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/1d/786aa70b5641667d5edfe40d339b4823a35f1dd5d0b9ca1e406775ce9739/bluecore_models-0.14.0.tar.gz", hash = "sha256:98aa52425c175560a4fbb09ed506e29564355d0ecef14e38db339ca85a93a9d5", size = 165055, upload-time = "2026-06-16T19:36:41.07Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/6b/1f339b0e63ddc53eb549f454cad9ae5aa3f1856ce6f24090700d0163ac2a/bluecore_models-0.15.0.tar.gz", hash = "sha256:97d79e3402966d1707a4a96f9a16d9179b1d89532f6b0a2df13f0c03159f3c47", size = 164747, upload-time = "2026-06-17T20:43:14.651Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/66/dfad066ada7924dc8536adacd18736c2bf45f54a1dfbc6c78759fcd26e19/bluecore_models-0.14.0-py3-none-any.whl", hash = "sha256:94b7ee501e2d6c73185d30626ba8db5988806d27a7240d4b1d6c20d2947fa746", size = 31013, upload-time = "2026-06-16T19:36:40.109Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/59/9a3565f626e36d77ca4712292ad5cdf09419009b1efd43d3f909bd155268/bluecore_models-0.15.0-py3-none-any.whl", hash = "sha256:aa13f9dafc305a350fe668e44f3ce0650ed75729929220a876db361a1925039e", size = 32052, upload-time = "2026-06-17T20:43:15.522Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why was this change made?

Replace handle_external_subject() in the works, instances, and hubs
PUT/POST routes with save_graph() from bluecore_models. This ensures
the API uses the same persistence logic as bluecore-workflows, including
URI minting, OtherResource extraction and linking, and Hub support
(added in bluecore-models 0.15.0). Unlike handle_external_subject(),
save_graph() also persists OtherResources referenced in the graph and
links them to their Works and Instances.

With this change, handle_external_subject() and its helpers _mint_uri()
and _update_graph() in bluecore_models.utils.graph are no longer used
by the API and could be removed from bluecore-models in a future cleanup.

A get_session_maker() dependency is added so the sessionmaker can be
injected and overridden in tests, avoiding cross-session deadlocks.
test_update_instance is updated to follow the POST→PUT pattern so
save_graph() can locate the existing record by its Bluecore URI.

Closes #193

## How was this change tested?

* unit tests

## Which documentation and/or configurations were updated?

n/a




