### PR TITLE
Unpin bluecore-models and sync

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,12 @@ description = "Blue Core API for managing BIBFRAME RDF data and workflows"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
+  "bluecore-models",
   "fastapi[standard]",
   "sqlalchemy",
   "pgvector",
   "psycopg2-binary>=2.9.10",
   "rdflib>=7.1.3",
-  "bluecore-models>=0.14.1",
   "python-multipart>=0.0.20",
   "fastapi-keycloak-middleware>=1.2.0",
   "typer>=0.15.4",

--- a/uv.lock
+++ b/uv.lock
@@ -81,7 +81,7 @@ wheels = [
 
 [[package]]
 name = "bluecore-api"
-version = "0.18.1"
+version = "0.18.3"
 source = { editable = "." }
 dependencies = [
     { name = "bluecore-models" },
@@ -115,7 +115,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bluecore-models", specifier = ">=0.14.1" },
+    { name = "bluecore-models" },
     { name = "fastapi", extras = ["standard"] },
     { name = "fastapi-keycloak-middleware", specifier = ">=1.2.0" },
     { name = "fastapi-mcp", specifier = ">=0.4.0" },


### PR DESCRIPTION
## Why was this change made?
So we can deploy and run bluecore_api without having to update the version of bluecore-models.



