### PR TITLE
208 remove auth for mcp get endpoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-api"
-version = "0.19.0"
+version = "0.19.2"
 description = "Blue Core API for managing BIBFRAME RDF data and workflows"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/bluecore_api/middleware/keycloak_auth.py
+++ b/src/bluecore_api/middleware/keycloak_auth.py
@@ -35,38 +35,42 @@ class CompatibleFastAPI(FastAPI):
         await self._asgi_app(scope, receive, send)
 
 
+
+def _with_api_root(paths: set[str]) -> set[str]:
+    """
+    The app is served both at the root and behind NGINX's "/api" root path, so
+    every public GET path needs both forms. List each once below and let this
+    expand it to {"/docs", "/api/docs"}
+    """
+    return {form for p in paths for form in (p, f"/api{p}")}
+
+
 class BypassKeycloakForGet:
     """Add specific GET paths to bypass keycloak authentication"""
 
-    EXACT_PATHS = {
-        "/",
-        "/api/",
-        "/docs",
-        "/api/docs",
-        "/openapi.json",
-        "/api/openapi.json",
-        "/api/favicon.ico",
-        "/favicon.ico",
-    }
+    EXACT_PATHS = _with_api_root(
+        {
+            "/",
+            "/docs",
+            "/openapi.json",
+            "/favicon.ico",
+        }
+    )
 
     """Add GET path prefixes (e.g., /instances/, /works/)"""
-    PREFIX_PATHS = {
-        "/instances/",
-        "/works/",
-        "/hubs/",
-        "/resources/",
-        "/api/instances/",
-        "/api/works/",
-        "/api/hubs/",
-        "/api/resources/",
-        "/change_documents/",
-        "/api/change_documents/",
-        "/search",
-        "/api/search",
-        "/api/cbd",
-        "/api/static/",
-        "/static/",
-    }
+    PREFIX_PATHS = _with_api_root(
+        {
+            "/instances/",
+            "/works/",
+            "/hubs/",
+            "/resources/",
+            "/change_documents/",
+            "/search",
+            "/cbd",
+            "/static/",
+            "/mcp"
+        }
+    )
 
     def __init__(self, app, keycloak_middleware):
         self.inner_app = app

--- a/src/bluecore_api/middleware/keycloak_auth.py
+++ b/src/bluecore_api/middleware/keycloak_auth.py
@@ -35,7 +35,6 @@ class CompatibleFastAPI(FastAPI):
         await self._asgi_app(scope, receive, send)
 
 
-
 def _with_api_root(paths: set[str]) -> set[str]:
     """
     The app is served both at the root and behind NGINX's "/api" root path, so
@@ -68,7 +67,7 @@ class BypassKeycloakForGet:
             "/search",
             "/cbd",
             "/static/",
-            "/mcp"
+            "/mcp",
         }
     )
 

--- a/tests/api/test_keycloak_bypass.py
+++ b/tests/api/test_keycloak_bypass.py
@@ -1,0 +1,105 @@
+"""Unit tests for BypassKeycloakForGet — which requests skip Keycloak auth.
+
+This middleware is the ASGI wrapper that decides, before Keycloak runs, whether
+a request is public. It is *not* exercised by the `client`/`app` fixtures (those
+use `base_app` directly and override the auth dependencies), so the bypass logic
+is tested here against the wrapper in isolation.
+
+The path cases are driven off BypassKeycloakForGet.EXACT_PATHS / PREFIX_PATHS so
+every allow-listed endpoint (and any added later) is covered automatically.
+"""
+
+import pytest
+
+from bluecore_api.middleware.keycloak_auth import BypassKeycloakForGet
+
+EXACT_PATHS = sorted(BypassKeycloakForGet.EXACT_PATHS)
+PREFIX_PATHS = sorted(BypassKeycloakForGet.PREFIX_PATHS)
+
+
+class _Recorder:
+    """Minimal ASGI app stub that records whether it was the one invoked."""
+
+    def __init__(self) -> None:
+        self.called = False
+
+    async def __call__(self, scope, receive, send) -> None:
+        self.called = True
+
+
+async def _route(method: str, path: str) -> tuple[_Recorder, _Recorder]:
+    """Send a request and see where the wrapper sends it.
+
+    There are two possible destinations:
+      - `inner`    = the app WITHOUT a login check (the request got let through)
+      - `keycloak` = the login check (the request has to prove who it is)
+
+    Hand the wrapper a fake request for the given method (GET, POST, ...) and
+    path (e.g. "/works/"), then return both destinations so the test can check
+    which one got used. Only one of them should ever be hit.
+    """
+    inner, keycloak = _Recorder(), _Recorder()
+    wrapper = BypassKeycloakForGet(app=inner, keycloak_middleware=keycloak)
+
+    # The wrapper hands these two callbacks straight to whichever destination it
+    # picks, and our fake destinations ignore them, so they can be empty stubs.
+    async def receive():  # never actually used by the stubs
+        return {}
+
+    async def send(message):  # never actually used by the stubs
+        return None
+
+    # This dict is the bare-minimum description of a web request that the wrapper
+    # needs to make its decision: the HTTP method and the URL path.
+    await wrapper({"type": "http", "method": method, "path": path}, receive, send)
+    return inner, keycloak
+
+
+# --- Set GET paths circumvent Keycloak Auth  ----------------------------------
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", EXACT_PATHS)
+async def test_get_exact_path_bypasses_keycloak(path):
+    """Every exact allow-listed path is public on GET."""
+    inner, keycloak = await _route("GET", path)
+    assert inner.called and not keycloak.called
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("prefix", PREFIX_PATHS)
+async def test_get_prefix_path_bypasses_keycloak(prefix):
+    """Every prefix allow-listed path is public on GET, including sub-paths
+    (e.g. /works/<id>), which is the whole point of matching by prefix."""
+    for path in (prefix, f"{prefix}some-sub-path"):
+        inner, keycloak = await _route("GET", path)
+        assert inner.called and not keycloak.called, path
+
+
+# --- Everything else still goes through Keycloak ------------------------------
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method", ["POST", "PUT", "PATCH", "DELETE"])
+@pytest.mark.parametrize("path", ["/works/123", "/mcp", "/hubs/", "/resources/x"])
+async def test_mutating_methods_still_require_auth(method, path):
+    """The bypass is GET-only; mutating verbs on allow-listed paths are protected."""
+    inner, keycloak = await _route(method, path)
+    assert keycloak.called and not inner.called
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "path", ["/some/private/route", "/admin", "/docs/extra", "/openapi.json/x"]
+)
+async def test_get_unlisted_path_requires_auth(path):
+    """Control: a GET that isn't allow-listed is not bypassed. Confirms the
+    bypass is path-driven (GET alone doesn't open a route) and that exact paths
+    match exactly (e.g. /docs/extra is not /docs)."""
+    inner, keycloak = await _route("GET", path)
+    assert keycloak.called and not inner.called
+
+
+# --- CORS preflight -----------------------------------------------------------
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["/works/", "/some/private/route"])
+async def test_options_always_bypasses(path):
+    """OPTIONS (CORS preflight) is always public, regardless of path."""
+    inner, keycloak = await _route("OPTIONS", path)
+    assert inner.called and not keycloak.called

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 
 [[package]]
@@ -81,7 +81,7 @@ wheels = [
 
 [[package]]
 name = "bluecore-api"
-version = "0.18.3"
+version = "0.19.2"
 source = { editable = "." }
 dependencies = [
     { name = "bluecore-models" },
@@ -569,6 +569,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
     { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
     { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
@@ -579,6 +580,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
     { url = "https://files.pythonhosted.org/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
     { url = "https://files.pythonhosted.org/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
@@ -589,6 +591,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
     { url = "https://files.pythonhosted.org/packages/c0/aa/687d6b12ffb505a4447567d1f3abea23bd20e73a5bed63871178e0831b7a/greenlet-3.2.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c17b6b34111ea72fc5a4e4beec9711d2226285f0386ea83477cbb97c30a3f3a5", size = 699218, upload-time = "2025-08-07T13:45:30.969Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
     { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },


### PR DESCRIPTION
### Closes #208 

## Why was this change made?
* updated  `BypassKeycloakForGet` to use `_with_api_root` to to dry up  "`/api` `/`" root paths
* Added tests for `BypassKeycloakForGet` and keycloak auth


## How was this change tested?
* Created `test_keycloak_bypass.py` to test Keycloak auth paths.


## Which documentation and/or configurations were updated?
N/A



