### PR TITLE
Fix/mcp permission update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-api"
-version = "0.20.0"
+version = "0.20.1"
 description = "Blue Core API for managing BIBFRAME RDF data and workflows"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/bluecore_api/app/main.py
+++ b/src/bluecore_api/app/main.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-from fastapi import Depends, FastAPI, HTTPException, Response
+from fastapi import Depends, FastAPI, HTTPException, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi_keycloak_middleware import (
@@ -9,8 +9,9 @@ from fastapi_keycloak_middleware import (
     CheckPermissions,
     KeycloakConfiguration,
     KeycloakMiddleware,
+    MatchStrategy,
+    get_auth,
 )
-from fastapi_keycloak_middleware.schemas.match_strategy import MatchStrategy
 from fastapi_mcp import AuthConfig, FastApiMCP
 
 from bluecore_api.app.config.logging_setup import setup_logging
@@ -80,6 +81,29 @@ base_app.include_router(change_documents, tags=["Change Documents"])
 base_app.include_router(batch_endpoints, tags=["Batches"])
 base_app.include_router(export_routes, tags=["Export"])
 
+# MCP write methods require a create/update permission
+_mcp_write_permission = CheckPermissions(
+    ["create", "update"], match_strategy=MatchStrategy.OR
+)
+
+
+async def mcp_permissions(request: Request, auth=Depends(get_auth)):
+    """
+    Auth for the MCP mount.
+    GET /mcp (the SSE/discovery stream) is public it's and bypassed upstream by
+    BypassKeycloakForGet, so get_auth is None here
+    """
+    if request.method == "GET":
+        return
+    _mcp_write_permission(user=None, auth=auth or [])
+
+
+mcp = FastApiMCP(
+    base_app,
+    auth_config=AuthConfig(dependencies=[Depends(mcp_permissions)]),
+)
+mcp.mount_http()
+
 # Serve CSS/images for HTML views. Templates reference these at `{{ BLUECORE_URL }}static/...` (see app/templating.py).
 STATIC_DIR = os.path.join(os.path.dirname(__file__), "static")
 
@@ -138,17 +162,6 @@ base_app.add_middleware(
     allow_headers=["*"],
 )
 
-mcp = FastApiMCP(
-    base_app,
-    auth_config=AuthConfig(
-        dependencies=[
-            Depends(
-                CheckPermissions(["create", "update"], match_strategy=MatchStrategy.OR)
-            )
-        ]
-    ),
-)
-
 
 @base_app.get("/")
 async def index():
@@ -168,6 +181,3 @@ async def favicon():
 @base_app.get("/context.jsonld")
 async def context_jsonld():
     return CONTEXT
-
-
-mcp.mount_http()

--- a/tests/api/test_mcp_server.py
+++ b/tests/api/test_mcp_server.py
@@ -5,11 +5,22 @@ Unit tests for the MCP (Model Context Protocol) server integration.
 import pytest
 
 
-def test_mcp_endpoint_exists(client):
-    """Test that the /mcp endpoint is mounted and accessible."""
+@pytest.fixture(autouse=True)
+def _fresh_mcp_transport():
+    """Give each test a fresh MCP session manager."""
+    from bluecore_api.app.main import mcp
+
+    transport = mcp._http_transport
+    transport._manager_started = False
+    transport._session_manager = None
+    transport._manager_task = None
+    yield
+
+
+def test_mcp_get_is_public(client):
+    """GET /mcp is public (no auth) and reaches the MCP app."""
     response = client.get("/mcp")
-    # The MCP endpoint exists and requires authentication, so expects 403
-    assert response.status_code == 403
+    assert response.status_code == 406
 
 
 def test_mcp_endpoint_post_without_auth(client):
@@ -27,6 +38,28 @@ def test_mcp_without_required_permissions(client):
     response = client.post("/mcp", json=payload, headers=headers)
     # Should be denied without required permissions
     assert response.status_code == 403
+
+
+def test_mcp_post_with_permissions_clears_gate(client):
+    """
+    POST /mcp as a create/update user passes the keyclaok auth and reaches the MCP app.
+    """
+    payload = {
+        "jsonrpc": "2.0",
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "test-client", "version": "1.0.0"},
+        },
+        "id": 1,
+    }
+    headers = {
+        "X-User": "cataloger",
+        "Accept": "application/json, text/event-stream",
+    }
+    response = client.post("/mcp", json=payload, headers=headers)
+    assert response.status_code == 200
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_mcp_server.py
+++ b/tests/api/test_mcp_server.py
@@ -20,6 +20,11 @@ def _fresh_mcp_transport():
 def test_mcp_get_is_public(keycloak_client):
     """GET /mcp is public (no auth) and reaches the MCP app."""
     response = keycloak_client.get("/mcp")
+    # 406 is the EXPECTED success signal here, not a failure: the GET cleared auth
+    # (BypassKeycloakForGet let it through) and reached the MCP app, which then
+    # rejected the bare request because MCP's SSE transport requires
+    # `Accept: text/event-stream`. The JSON-RPC -32600 below confirms the response
+    # came from MCP itself. (If /mcp were NOT public, Keycloak would return 401.)
     assert response.status_code == 406
     assert response.json()["error"]["code"] == -32600
 

--- a/tests/api/test_mcp_server.py
+++ b/tests/api/test_mcp_server.py
@@ -20,22 +20,25 @@ def _fresh_mcp_transport():
 def test_mcp_get_is_public(client):
     """GET /mcp is public (no auth) and reaches the MCP app."""
     response = client.get("/mcp")
+def test_mcp_get_is_public(keycloak_client):
+    response = keycloak_client.get("/mcp")
     assert response.status_code == 406
+    assert response.json()["error"]["code"] == -32600
 
 
-def test_mcp_endpoint_post_without_auth(client):
-    """Test that MCP endpoint requires authentication for POST requests."""
+def test_mcp_post_without_auth_is_rejected_by_keycloak(keycloak_client):
+    """Anonymous POST /mcp is not bypassed, so Keycloak rejects it with 401."""
     payload = {"jsonrpc": "2.0", "method": "initialize", "params": {}, "id": 1}
-    response = client.post("/mcp", json=payload)
-    # Should fail without proper authentication (create/update permissions)
-    assert response.status_code == 403
+    response = keycloak_client.post("/mcp", json=payload)
+    assert response.status_code == 401
 
 
 def test_mcp_without_required_permissions(client):
     """Test that MCP access is denied without create/update permissions."""
+def test_mcp_without_required_permissions(keycloak_client):
     payload = {"jsonrpc": "2.0", "method": "initialize", "params": {}, "id": 1}
     headers = {"X-User": "public"}  # public user has no special roles
-    response = client.post("/mcp", json=payload, headers=headers)
+    response = keycloak_client.post("/mcp", json=payload, headers=headers)
     # Should be denied without required permissions
     assert response.status_code == 403
 
@@ -44,6 +47,7 @@ def test_mcp_post_with_permissions_clears_gate(client):
     """
     POST /mcp as a create/update user passes the keyclaok auth and reaches the MCP app.
     """
+def test_mcp_post_with_permissions_clears_gate(keycloak_client):
     payload = {
         "jsonrpc": "2.0",
         "method": "initialize",
@@ -58,7 +62,7 @@ def test_mcp_post_with_permissions_clears_gate(client):
         "X-User": "cataloger",
         "Accept": "application/json, text/event-stream",
     }
-    response = client.post("/mcp", json=payload, headers=headers)
+    response = keycloak_client.post("/mcp", json=payload, headers=headers)
     assert response.status_code == 200
 
 

--- a/tests/api/test_mcp_server.py
+++ b/tests/api/test_mcp_server.py
@@ -17,10 +17,8 @@ def _fresh_mcp_transport():
     yield
 
 
-def test_mcp_get_is_public(client):
-    """GET /mcp is public (no auth) and reaches the MCP app."""
-    response = client.get("/mcp")
 def test_mcp_get_is_public(keycloak_client):
+    """GET /mcp is public (no auth) and reaches the MCP app."""
     response = keycloak_client.get("/mcp")
     assert response.status_code == 406
     assert response.json()["error"]["code"] == -32600
@@ -33,9 +31,8 @@ def test_mcp_post_without_auth_is_rejected_by_keycloak(keycloak_client):
     assert response.status_code == 401
 
 
-def test_mcp_without_required_permissions(client):
-    """Test that MCP access is denied without create/update permissions."""
 def test_mcp_without_required_permissions(keycloak_client):
+    """Test that MCP access is denied without create/update permissions."""
     payload = {"jsonrpc": "2.0", "method": "initialize", "params": {}, "id": 1}
     headers = {"X-User": "public"}  # public user has no special roles
     response = keycloak_client.post("/mcp", json=payload, headers=headers)
@@ -43,11 +40,10 @@ def test_mcp_without_required_permissions(keycloak_client):
     assert response.status_code == 403
 
 
-def test_mcp_post_with_permissions_clears_gate(client):
+def test_mcp_post_with_permissions_clears_gate(keycloak_client):
     """
     POST /mcp as a create/update user passes the keyclaok auth and reaches the MCP app.
     """
-def test_mcp_post_with_permissions_clears_gate(keycloak_client):
     payload = {
         "jsonrpc": "2.0",
         "method": "initialize",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,6 +180,44 @@ def client(mocker, db_session, app):
     Base.metadata.drop_all(bind=db_session.get_bind())
 
 
+class _StubKeycloak:
+    """
+    Stand-in for the external Keycloak Server.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if dict(scope.get("headers") or ()).get(b"x-user"):
+            await self.app(scope, receive, send)
+        else:
+            from fastapi.responses import JSONResponse
+
+            await JSONResponse({"detail": "Not authenticated"}, status_code=401)(
+                scope, receive, send
+            )
+
+
+@pytest.fixture
+def keycloak_client(app):
+    """
+    TestClient that routes through "BypassKeycloakForGet" wrapper.
+    """
+    from bluecore_api.middleware.keycloak_auth import BypassKeycloakForGet
+
+    bypass = BypassKeycloakForGet(app=app, keycloak_middleware=_StubKeycloak(app))
+
+    async def stack(scope, receive, send):
+        if scope["type"] == "http":
+            await bypass(scope, receive, send)
+        else:
+            await app(scope, receive, send)
+
+    with TestClient(stack) as kk_client:
+        yield kk_client
+
+
 @pytest.fixture
 def vector_client():
     # bluecore_api.database.get_vector_client() is configured to use this

--- a/uv.lock
+++ b/uv.lock
@@ -81,7 +81,7 @@ wheels = [
 
 [[package]]
 name = "bluecore-api"
-version = "0.20.0"
+version = "0.20.1"
 source = { editable = "." }
 dependencies = [
     { name = "bluecore-models" },


### PR DESCRIPTION
## Why was this change made?
after doing soem more testing I reliazed the MCP endpoint needed to be updated in main.py to follow a similar pattern.

## How was this change tested?
created some new tests to test auth in api, and tests now pass with integration tests (PR for that coming soon)


## Which documentation and/or configurations were updated?

N/A


