### PR TITLE
fix: sinopia context error

### DIFF
--- a/src/bluecore_api/app/main.py
+++ b/src/bluecore_api/app/main.py
@@ -3,7 +3,7 @@ import sys
 
 from fastapi import Depends, FastAPI, HTTPException, Response
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, JSONResponse
 from fastapi_keycloak_middleware import (
     AuthorizationMethod,
     CheckPermissions,
@@ -167,7 +167,8 @@ async def favicon():
 
 @base_app.get("/context.jsonld")
 async def context_jsonld():
-    return CONTEXT
+    # Sinopia rejects both a bare mapping anda non-JSON-LD media type.
+    return JSONResponse({"@context": CONTEXT}, media_type="application/ld+json")
 
 
 mcp.mount_http()


### PR DESCRIPTION
## Why was this change made?
This returns Context in the form Sinopia expects and resolves the current JSONLD error that Sinopia is encountering with CONTEXT.


## How was this change tested?
WIth Sinopia to ensure the error resolved.


## Which documentation and/or configurations were updated?
n/a



