### PR TITLE
workflow: added stack integration

### DIFF
--- a/.github/workflows/stack-integration.yml
+++ b/.github/workflows/stack-integration.yml
@@ -74,15 +74,17 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: blue-core-lod/bluecore-stack
-          RUN_ID: ${{ steps.dispatch.outputs.workflow-id }}
           RUN_URL: ${{ steps.dispatch.outputs.workflow-url }}
           POLL_INTERVAL: 30      # seconds between status checks
           MAX_POLLS: 90          # 90 * 30s = 45m
         shell: bash
         run: |
           set -euo pipefail
-          if [ -z "${RUN_ID}" ]; then
-            echo "::error::bluecore-stack run id was not resolved; cannot wait"
+          # The action sets workflow-url but not reliably workflow-id when not
+          # waiting, so derive the run id from the URL's last path segment.
+          RUN_ID="${RUN_URL##*/}"
+          if [ -z "${RUN_URL}" ] || ! [[ "${RUN_ID}" =~ ^[0-9]+$ ]]; then
+            echo "::error::Could not derive a bluecore-stack run id from '${RUN_URL}'"
             exit 1
           fi
           for i in $(seq 1 "$MAX_POLLS"); do

--- a/.github/workflows/stack-integration.yml
+++ b/.github/workflows/stack-integration.yml
@@ -34,57 +34,21 @@ jobs:
           repositories: bluecore-stack
 
       # Dispatch the bluecore-stack integration workflow and wait for its result.
+      # Uses RUN_NAME for the remote run (passed via the "run_name"
+      # input, which bluecore-stack echoes into its top-level run-name:) so the
+      # action correlates THIS exact run by name.
       - name: Trigger bluecore-stack integration tests and wait
+        uses: aurelien-baudet/workflow-dispatch@v4
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          REPO: blue-core-lod/bluecore-stack
-          WORKFLOW: bluecore-integration-test.yml
-          API_REF: ${{ github.head_ref }}
-          POLL_INTERVAL: 30      # seconds between status checks
-          MAX_POLLS: 90          # 90 * 30s = 45m, matching the old timeout
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          # Highest existing run id before we dispatch (run ids only ever grow).
-          before=$(gh run list --repo "$REPO" --workflow "$WORKFLOW" \
-            --json databaseId --jq '[.[].databaseId] | max // 0')
-          echo "Latest existing run id before dispatch: $before"
-
-          echo "Dispatching $WORKFLOW (api_ref=$API_REF)..."
-          gh workflow run "$WORKFLOW" --repo "$REPO" --ref main -f api_ref="$API_REF"
-
-          # Wait for the new run (id > before) to register, then capture it.
-          run_id=""
-          for i in $(seq 1 24); do
-            run_id=$(gh run list --repo "$REPO" --workflow "$WORKFLOW" \
-              --json databaseId \
-              --jq "[.[].databaseId] | map(select(. > $before)) | max // empty")
-            [ -n "$run_id" ] && break
-            echo "  ...new run not visible yet (attempt $i), retrying in 5s"
-            sleep 5
-          done
-          if [ -z "$run_id" ]; then
-            echo "::error::Dispatched but could not locate the new bluecore-stack run"
-            exit 1
-          fi
-          run_url="https://github.com/$REPO/actions/runs/$run_id"
-          echo "Tracking run: $run_url"
-
-          # Poll to completion and mirror the conclusion as this job's result.
-          for i in $(seq 1 "$MAX_POLLS"); do
-            read -r status conclusion < <(gh run view "$run_id" --repo "$REPO" \
-              --json status,conclusion --jq '"\(.status) \(.conclusion)"')
-            echo "[$i/$MAX_POLLS] status=$status conclusion=$conclusion"
-            if [ "$status" = "completed" ]; then
-              if [ "$conclusion" = "success" ]; then
-                echo "Integration tests passed: $run_url"
-                exit 0
-              fi
-              echo "::error::Integration tests concluded '$conclusion': $run_url"
-              exit 1
-            fi
-            sleep "$POLL_INTERVAL"
-          done
-          echo "::error::Timed out after $((MAX_POLLS * POLL_INTERVAL))s waiting for $run_url"
-          exit 1
+          RUN_NAME: api-integration-${{ github.run_id }}-${{ github.run_attempt }}
+        with:
+          repo: blue-core-lod/bluecore-stack
+          workflow: bluecore-integration-test.yml
+          ref: main
+          token: ${{ steps.app-token.outputs.token }}
+          run-name: ${{ env.RUN_NAME }}
+          wait-for-completion: true
+          wait-for-completion-timeout: 45m
+          wait-for-completion-interval: 30s
+          display-workflow-run-url: true
+          inputs: '{ "api_ref": "${{ github.head_ref }}", "run_name": "${{ env.RUN_NAME }}" }'

--- a/.github/workflows/stack-integration.yml
+++ b/.github/workflows/stack-integration.yml
@@ -33,14 +33,58 @@ jobs:
           owner: blue-core-lod
           repositories: bluecore-stack
 
+      # Dispatch the bluecore-stack integration workflow and wait for its result.
       - name: Trigger bluecore-stack integration tests and wait
-        uses: aurelien-baudet/workflow-dispatch@v2
-        with:
-          repo: blue-core-lod/bluecore-stack
-          workflow: bluecore-integration-test.yml
-          ref: main
-          token: ${{ steps.app-token.outputs.token }}
-          wait-for-completion: true
-          wait-for-completion-timeout: 45m
-          wait-for-completion-interval: 30s
-          inputs: '{ "api_ref": "${{ github.head_ref }}" }'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: blue-core-lod/bluecore-stack
+          WORKFLOW: bluecore-integration-test.yml
+          API_REF: ${{ github.head_ref }}
+          POLL_INTERVAL: 30      # seconds between status checks
+          MAX_POLLS: 90          # 90 * 30s = 45m, matching the old timeout
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Highest existing run id before we dispatch (run ids only ever grow).
+          before=$(gh run list --repo "$REPO" --workflow "$WORKFLOW" \
+            --json databaseId --jq '[.[].databaseId] | max // 0')
+          echo "Latest existing run id before dispatch: $before"
+
+          echo "Dispatching $WORKFLOW (api_ref=$API_REF)..."
+          gh workflow run "$WORKFLOW" --repo "$REPO" --ref main -f api_ref="$API_REF"
+
+          # Wait for the new run (id > before) to register, then capture it.
+          run_id=""
+          for i in $(seq 1 24); do
+            run_id=$(gh run list --repo "$REPO" --workflow "$WORKFLOW" \
+              --json databaseId \
+              --jq "[.[].databaseId] | map(select(. > $before)) | max // empty")
+            [ -n "$run_id" ] && break
+            echo "  ...new run not visible yet (attempt $i), retrying in 5s"
+            sleep 5
+          done
+          if [ -z "$run_id" ]; then
+            echo "::error::Dispatched but could not locate the new bluecore-stack run"
+            exit 1
+          fi
+          run_url="https://github.com/$REPO/actions/runs/$run_id"
+          echo "Tracking run: $run_url"
+
+          # Poll to completion and mirror the conclusion as this job's result.
+          for i in $(seq 1 "$MAX_POLLS"); do
+            read -r status conclusion < <(gh run view "$run_id" --repo "$REPO" \
+              --json status,conclusion --jq '"\(.status) \(.conclusion)"')
+            echo "[$i/$MAX_POLLS] status=$status conclusion=$conclusion"
+            if [ "$status" = "completed" ]; then
+              if [ "$conclusion" = "success" ]; then
+                echo "Integration tests passed: $run_url"
+                exit 0
+              fi
+              echo "::error::Integration tests concluded '$conclusion': $run_url"
+              exit 1
+            fi
+            sleep "$POLL_INTERVAL"
+          done
+          echo "::error::Timed out after $((MAX_POLLS * POLL_INTERVAL))s waiting for $run_url"
+          exit 1

--- a/.github/workflows/stack-integration.yml
+++ b/.github/workflows/stack-integration.yml
@@ -1,0 +1,46 @@
+name: Stack Integration Tests
+
+# Trigger the bluecore-stack integration test suite against THIS PR's branch and
+# wait for the result, so it shows up as a check on the PR. The bluecore-stack
+# workflow builds the API image from "api_ref" and runs the full suite.
+#
+# Auth is via an org GitHub App. Requires:
+#   - vars.STACK_DISPATCH_APP_ID             -> the App's App ID
+#   - secrets.STACK_DISPATCH_APP_PRIVATE_KEY -> the App's private key (.pem contents)
+# The App must be installed on blue-core-lod/bluecore-stack with
+# Actions: Read & write.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# Cancel superseded runs when new commits are pushed to the same PR.
+concurrency:
+  group: stack-integration-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  stack-integration:
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      # Mint a short-lived installation token scoped to bluecore-stack.
+      - name: Mint bluecore-stack token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.STACK_DISPATCH_APP_ID }}
+          private-key: ${{ secrets.STACK_DISPATCH_APP_PRIVATE_KEY }}
+          owner: blue-core-lod
+          repositories: bluecore-stack
+
+      - name: Trigger bluecore-stack integration tests and wait
+        uses: aurelien-baudet/workflow-dispatch@v2
+        with:
+          repo: blue-core-lod/bluecore-stack
+          workflow: bluecore-integration-test.yml
+          ref: main
+          token: ${{ steps.app-token.outputs.token }}
+          wait-for-completion: true
+          wait-for-completion-timeout: 45m
+          wait-for-completion-interval: 30s
+          inputs: '{ "api_ref": "${{ github.head_ref }}" }'

--- a/.github/workflows/stack-integration.yml
+++ b/.github/workflows/stack-integration.yml
@@ -33,11 +33,12 @@ jobs:
           owner: blue-core-lod
           repositories: bluecore-stack
 
-      # Dispatch the bluecore-stack integration workflow and wait for its result.
-      # Uses RUN_NAME for the remote run (passed via the "run_name"
-      # input, which bluecore-stack echoes into its top-level run-name:) so the
-      # action correlates THIS exact run by name.
-      - name: Trigger bluecore-stack integration tests and wait
+      # Dispatch the bluecore-stack integration workflow but DON'T wait here, so
+      # this step returns in seconds with the run's URL/id. RUN_NAME is echoed by
+      # bluecore-stack into its top-level run-name:, letting the action correlate
+      # THIS exact run by name.
+      - name: Trigger bluecore-stack integration tests
+        id: dispatch
         uses: aurelien-baudet/workflow-dispatch@v4
         env:
           RUN_NAME: api-integration-${{ github.run_id }}-${{ github.run_attempt }}
@@ -47,8 +48,56 @@ jobs:
           ref: main
           token: ${{ steps.app-token.outputs.token }}
           run-name: ${{ env.RUN_NAME }}
-          wait-for-completion: true
-          wait-for-completion-timeout: 45m
-          wait-for-completion-interval: 30s
+          wait-for-completion: false
           display-workflow-run-url: true
+          display-workflow-run-url-interval: 15s
+          display-workflow-run-url-timeout: 5m
           inputs: '{ "api_ref": "${{ github.head_ref }}", "run_name": "${{ env.RUN_NAME }}" }'
+
+      # Surface the link as soon as the run is identified in the job summary and
+      # as a top-of-run notice annotation.
+      - name: Link to bluecore-stack run
+        if: ${{ steps.dispatch.outputs.workflow-url }}
+        env:
+          RUN_URL: ${{ steps.dispatch.outputs.workflow-url }}
+        shell: bash
+        run: |
+          {
+            echo "### bluecore-stack integration run"
+            echo ""
+            echo "Following: ${RUN_URL}"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::notice title=bluecore-stack integration run::${RUN_URL}"
+
+      # Now block on that exact run id until it finishes, mirroring its result.
+      - name: Wait for bluecore-stack run to complete
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: blue-core-lod/bluecore-stack
+          RUN_ID: ${{ steps.dispatch.outputs.workflow-id }}
+          RUN_URL: ${{ steps.dispatch.outputs.workflow-url }}
+          POLL_INTERVAL: 30      # seconds between status checks
+          MAX_POLLS: 90          # 90 * 30s = 45m
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${RUN_ID}" ]; then
+            echo "::error::bluecore-stack run id was not resolved; cannot wait"
+            exit 1
+          fi
+          for i in $(seq 1 "$MAX_POLLS"); do
+            read -r status conclusion < <(gh run view "$RUN_ID" --repo "$REPO" \
+              --json status,conclusion --jq '"\(.status) \(.conclusion)"')
+            echo "[$i/$MAX_POLLS] status=$status conclusion=$conclusion"
+            if [ "$status" = "completed" ]; then
+              if [ "$conclusion" = "success" ]; then
+                echo "Integration tests passed: ${RUN_URL}"
+                exit 0
+              fi
+              echo "::error::Integration tests concluded '$conclusion': ${RUN_URL}"
+              exit 1
+            fi
+            sleep "$POLL_INTERVAL"
+          done
+          echo "::error::Timed out after $((MAX_POLLS * POLL_INTERVAL))s waiting for ${RUN_URL}"
+          exit 1


### PR DESCRIPTION
### Closes #248

## Why was this change made?
Added cross-repo triggers for integration tests with the bluecore-stack

## How was this change tested?
testing currently with this PR (please standby)

## Which documentation and/or configurations were updated?
n/a

## Test Flow
Lives in the `bluecore-stack`.
* Github Action: https://github.com/blue-core-lod/bluecore-stack/actions/workflows/bluecore-integration-test.yml
* [bluecore-integration-test.yml](https://github.com/blue-core-lod/bluecore-stack/blob/main/.github/workflows/bluecore-integration-test.yml)


## Test Flow:

1. Workflow triggered with PR's for: bluecore_api, bluecore-models, bluecore-workflows, marva, sinopia (bluecore_api for this example)
2. bluecore_api PR's workflow executes the bluecore-stack integration tests (Integration tests build the image from your PR's branch and tests it against the entire bluecore suite's `:Latest` image release to ensure there are no breaking changes with the PR)
3. bluecore-stack integration tests report back to bluecore_api's PR as PASS or FAIL (Fail in this PR for example)

