### PR TITLE
Fixes tests to use adminMetadata/derivedFrom construction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-api"
-version = "0.20.1"
+version = "0.20.2"
 description = "Blue Core API for managing BIBFRAME RDF data and workflows"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/api/test_cbd.py
+++ b/tests/api/test_cbd.py
@@ -95,7 +95,12 @@ def test_reorder_instance_types():
 def test_cbd(client: TestClient, db_session: Session):
     work = add_work(client, db_session)
     work_id: int = work.id
-    work_derived_from: str = work.data["derivedFrom"]["@id"]
+    admin_metadata: list = work.data["adminMetadata"]
+    work_derived_from: str = next(
+        admin_md["derivedFrom"]["@id"]
+        for admin_md in admin_metadata
+        if "derivedFrom" in admin_md
+    )
     instances = add_instances(client, db_session, work_id, work_derived_from)
 
     headers = {"Accept": "application/cbd+xml"}

--- a/tests/api/test_hub.py
+++ b/tests/api/test_hub.py
@@ -87,7 +87,7 @@ def test_get_expanded_hub(client, db_session):
     assert len(expanded_graph) == 5
 
 
-def test_create_hub(client, mocker):
+def test_create_hub(client, mocker, derived_from_sparql):
     original_graph = init_graph()
     original_graph.parse(
         data=pathlib.Path("tests/blue-core-hub.jsonld").read_text(), format="json-ld"
@@ -109,8 +109,8 @@ def test_create_hub(client, mocker):
 
     assert len(original_graph) != len(new_graph)
 
-    new_hub_uri = rdflib.URIRef(data["uri"])
-    derived_from = new_graph.value(subject=new_hub_uri, predicate=BF.derivedFrom)
+    results = new_graph.query(derived_from_sparql)
+    derived_from = results.bindings[0]["derived_from"]
 
     assert str(derived_from).startswith(
         "http://id.loc.gov/resources/hubs/62a26d82-4e65-c696-afed-b12d215a35b1"

--- a/tests/api/test_instance.py
+++ b/tests/api/test_instance.py
@@ -211,7 +211,7 @@ def test_get_instance_html(client, db_session):
 # cbd requires work & instance and will be tested in test_cbd.py
 
 
-def test_create_instance(client):
+def test_create_instance(client, derived_from_sparql):
     original_graph = init_graph()
     original_graph.parse(
         data=pathlib.Path("tests/blue-core-instance.jsonld").read_text(),
@@ -231,14 +231,14 @@ def test_create_instance(client):
 
     assert len(original_graph) != len(new_graph)
 
-    new_work_uri = rdflib.URIRef(data["uri"])
-    derived_from = new_graph.value(subject=new_work_uri, predicate=BF.derivedFrom)
+    results = new_graph.query(derived_from_sparql)
+    derived_from = results.bindings[0]["derived_from"]
 
     assert str(derived_from).startswith(
         "https://bluecore.info/instances/75d831b9-e0d6-40f0-abb3-e9130622eb8a"
     )
 
-    assert str(new_work_uri).startswith("https://bcld.info/instances"), (
+    assert data["uri"].startswith("https://bcld.info/instances"), (
         "Minted URI uses default base url https://bcld.info/"
     )
 

--- a/tests/api/test_work.py
+++ b/tests/api/test_work.py
@@ -196,7 +196,7 @@ def test_get_work_html(client, db_session):
 # cbd requires work & instance and will be tested in test_cbd.py
 
 
-def test_create_work(client, mocker):
+def test_create_work(client, mocker, derived_from_sparql):
     original_graph = init_graph()
     original_graph.parse(
         data=pathlib.Path("tests/blue-core-work.jsonld").read_text(), format="json-ld"
@@ -219,8 +219,9 @@ def test_create_work(client, mocker):
 
     assert len(original_graph) != len(new_graph)
 
-    new_work_uri = rdflib.URIRef(data["uri"])
-    derived_from = new_graph.value(subject=new_work_uri, predicate=BF.derivedFrom)
+    results = new_graph.query(derived_from_sparql)
+
+    derived_from = results.bindings[0]["derived_from"]
 
     assert str(derived_from).startswith(
         "https://api.sinopia.io/resources/370ccc0a-3280-4036-9ca1-d9b5d5daf7df"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -231,3 +231,11 @@ def vector_client():
     client.delete(collection_name="hubs", filter="version == 1")
     client.delete(collection_name="instances", filter="version == 1")
     client.delete(collection_name="works", filter="version == 1")
+
+
+@pytest.fixture(scope="session")
+def derived_from_sparql():
+    return """prefix bf: <http://id.loc.gov/ontologies/bibframe/>
+SELECT ?derived_from WHERE {
+  ?admin_metadata bf:derivedFrom ?derived_from .
+}"""

--- a/uv.lock
+++ b/uv.lock
@@ -81,7 +81,7 @@ wheels = [
 
 [[package]]
 name = "bluecore-api"
-version = "0.20.1"
+version = "0.20.2"
 source = { editable = "." }
 dependencies = [
     { name = "bluecore-models" },
@@ -146,7 +146,7 @@ dev = [
 
 [[package]]
 name = "bluecore-models"
-version = "0.17.0"
+version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "alembic" },
@@ -157,9 +157,9 @@ dependencies = [
     { name = "tenacity" },
     { name = "transformers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/4f/731c9b0f369c945b567ff9b659d8e9107a7f0c7a2889da4d4f56a41af832/bluecore_models-0.17.0.tar.gz", hash = "sha256:5ea08a434ed3925ceb61dc210b97cdd95daa69b60a390f4f73b9a90b70059377", size = 166330, upload-time = "2026-06-24T19:08:38.156Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/3b/23bd1695228e0e3eadaf3b40d6fd5d3e8a7e7afa196597d31a27f9852893/bluecore_models-0.18.0.tar.gz", hash = "sha256:4c2219d439d088bfb848917cc492c1794c65807d58ba775d6c103ce0063d7e07", size = 168879, upload-time = "2026-06-25T21:18:17.627Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/d8/dea6a14d296abe8521b6047bedb157f3f1d94676abbd27e7c0ecc61915fd/bluecore_models-0.17.0-py3-none-any.whl", hash = "sha256:ce3505dbb8194dc31de3b59b4c4eda492a53f8ebb9dc527e4426f72abfb8f395", size = 31107, upload-time = "2026-06-24T19:08:37.107Z" },
+    { url = "https://files.pythonhosted.org/packages/70/6c/9b84e4e5acc37741ec07d583b07276644f01d27855e48b4a9eea9a57a1a5/bluecore_models-0.18.0-py3-none-any.whl", hash = "sha256:60514543d26c411f45288d3f88d1c519ec7373115c7409f63dffe2ab3e99eb8a", size = 33364, upload-time = "2026-06-25T21:18:16.794Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why was this change made?
Fixes #242

## How was this change tested?
Adjusted unit tests


## Which documentation and/or configurations were updated?
`tests/conftest.py`



