### PR TITLE
236 update put post endpoints to accept ld json

### DIFF
--- a/src/bluecore_api/app/routes/hubs.py
+++ b/src/bluecore_api/app/routes/hubs.py
@@ -12,6 +12,8 @@ from pymilvus import MilvusClient
 from rdflib import RDF
 from sqlalchemy.orm import Session
 
+from bluecore_api.app.utils.deserializer import deserialize, request_body_openapi
+from bluecore_api.app.utils.examples import HUB_EXAMPLE
 from bluecore_api.app.utils.serialize.response_generator import as_jsonld
 from bluecore_api.app.utils.serializer import serialize
 from bluecore_api.constants import CONTEXT_URL
@@ -89,9 +91,10 @@ async def get_embedding(
     dependencies=[Depends(CheckPermissions(["create"]))],
     status_code=201,
     operation_id="create_hub",
+    openapi_extra=request_body_openapi(HubCreateSchema, HUB_EXAMPLE),
 )
 async def create_hub(
-    hub: HubCreateSchema,
+    hub: HubCreateSchema = Depends(deserialize(HubCreateSchema)),
     db: Session = Depends(get_db),
     session_maker=Depends(get_session_maker),
 ):
@@ -109,10 +112,11 @@ async def create_hub(
     response_model=HubSchema,
     dependencies=[Depends(CheckPermissions(["update"]))],
     operation_id="update_hub",
+    openapi_extra=request_body_openapi(HubUpdateSchema, HUB_EXAMPLE),
 )
 async def update_hub(
     hub_uuid: str,
-    hub: HubUpdateSchema,
+    hub: HubUpdateSchema = Depends(deserialize(HubUpdateSchema)),
     db: Session = Depends(get_db),
     session_maker=Depends(get_session_maker),
 ):

--- a/src/bluecore_api/app/routes/instances.py
+++ b/src/bluecore_api/app/routes/instances.py
@@ -12,6 +12,8 @@ from pymilvus import MilvusClient
 from rdflib import RDF, URIRef
 from sqlalchemy.orm import Session
 
+from bluecore_api.app.utils.deserializer import deserialize, request_body_openapi
+from bluecore_api.app.utils.examples import INSTANCE_EXAMPLE
 from bluecore_api.app.utils.serialize.response_generator import as_html
 from bluecore_api.app.utils.serializer import (
     serialize,
@@ -97,9 +99,10 @@ async def get_embedding(
     dependencies=[Depends(CheckPermissions(["create"]))],
     status_code=201,
     operation_id="new_instance",
+    openapi_extra=request_body_openapi(InstanceCreateSchema, INSTANCE_EXAMPLE),
 )
 async def create_instance(
-    instance: InstanceCreateSchema,
+    instance: InstanceCreateSchema = Depends(deserialize(InstanceCreateSchema)),
     db: Session = Depends(get_db),
     session_maker=Depends(get_session_maker),
 ):
@@ -128,10 +131,11 @@ async def create_instance(
     response_model=InstanceSchema,
     dependencies=[Depends(CheckPermissions(["update"]))],
     operation_id="update_instance",
+    openapi_extra=request_body_openapi(InstanceUpdateSchema, INSTANCE_EXAMPLE),
 )
 async def update_instance(
     instance_uuid: str,
-    instance: InstanceUpdateSchema,
+    instance: InstanceUpdateSchema = Depends(deserialize(InstanceUpdateSchema)),
     db: Session = Depends(get_db),
     session_maker=Depends(get_session_maker),
 ):

--- a/src/bluecore_api/app/routes/works.py
+++ b/src/bluecore_api/app/routes/works.py
@@ -12,6 +12,8 @@ from pymilvus import MilvusClient
 from rdflib import RDF
 from sqlalchemy.orm import Session
 
+from bluecore_api.app.utils.deserializer import deserialize, request_body_openapi
+from bluecore_api.app.utils.examples import WORK_EXAMPLE
 from bluecore_api.app.utils.serialize.response_generator import as_html
 from bluecore_api.app.utils.serializer import serialize
 from bluecore_api.constants import CONTEXT_URL
@@ -89,9 +91,10 @@ async def get_embedding(
     dependencies=[Depends(CheckPermissions(["create"]))],
     status_code=201,
     operation_id="get_works",
+    openapi_extra=request_body_openapi(WorkCreateSchema, WORK_EXAMPLE),
 )
 async def create_work(
-    work: WorkCreateSchema,
+    work: WorkCreateSchema = Depends(deserialize(WorkCreateSchema)),
     db: Session = Depends(get_db),
     session_maker=Depends(get_session_maker),
 ):
@@ -109,10 +112,11 @@ async def create_work(
     response_model=WorkSchema,
     dependencies=[Depends(CheckPermissions(["update"]))],
     operation_id="update_work",
+    openapi_extra=request_body_openapi(WorkUpdateSchema, WORK_EXAMPLE),
 )
 async def update_work(
     work_uuid: str,
-    work: WorkUpdateSchema,
+    work: WorkUpdateSchema = Depends(deserialize(WorkUpdateSchema)),
     db: Session = Depends(get_db),
     session_maker=Depends(get_session_maker),
 ):

--- a/src/bluecore_api/app/utils/deserializer.py
+++ b/src/bluecore_api/app/utils/deserializer.py
@@ -1,7 +1,7 @@
 import json
 from typing import Any, Callable, Type
 
-from fastapi import Request
+from fastapi import HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from pydantic import BaseModel, ValidationError
 
@@ -21,7 +21,10 @@ def deserialize(schema: Type[BaseModel]) -> Callable:
     """
 
     async def dependency(request: Request) -> BaseModel:
-        payload = await request.json()
+        try:
+            payload = await request.json()
+        except json.JSONDecodeError as error:
+            raise HTTPException(status_code=422, detail=f"Invalid JSON body: {error}")
         content_type = request.headers.get("content-type", "").split(";")[0].strip()
 
         # Raw JSON-LD (application/ld+json): the whole body is the graph, so wrap

--- a/src/bluecore_api/app/utils/deserializer.py
+++ b/src/bluecore_api/app/utils/deserializer.py
@@ -9,6 +9,25 @@ JSONLD_CONTENT_TYPE = "application/ld+json"
 SINOPIA_CONTENT_TYPE = "application/vnd.sinopia+json"
 
 
+async def _request_payload(request: Request) -> tuple[Any, str]:
+    """Read the JSON body and normalized request media type."""
+    try:
+        payload = await request.json()
+    except json.JSONDecodeError as error:
+        raise HTTPException(status_code=422, detail=f"Invalid JSON body: {error}")
+
+    content_type = request.headers.get("content-type", "").split(";")[0].strip()
+    return payload, content_type
+
+
+def _validate_schema(schema: Type[BaseModel], payload: Any) -> BaseModel:
+    """Validate payload as a FastAPI request body."""
+    try:
+        return schema.model_validate(payload)
+    except ValidationError as error:
+        raise RequestValidationError(error.errors()) from error
+
+
 def deserialize(schema: Type[BaseModel]) -> Callable:
     """
     FastAPI dependency parsing a PUT/POST body by Content-Type into 'schema'.
@@ -21,24 +40,17 @@ def deserialize(schema: Type[BaseModel]) -> Callable:
     """
 
     async def dependency(request: Request) -> BaseModel:
-        try:
-            payload = await request.json()
-        except json.JSONDecodeError as error:
-            raise HTTPException(status_code=422, detail=f"Invalid JSON body: {error}")
-        content_type = request.headers.get("content-type", "").split(";")[0].strip()
+        payload, content_type = await _request_payload(request)
 
         # Raw JSON-LD (application/ld+json): the whole body is the graph, so wrap
         # it as the schema's 'data' string.
         if content_type == JSONLD_CONTENT_TYPE:
-            return schema(data=json.dumps(payload))
+            payload = {"data": json.dumps(payload)}
 
         # Sinopia (application/vnd.sinopia+json, or application/json for backwards
         # compatibility): already shaped like the schema
         # ({"data": "<json-ld string>", ...}), so validate it directly
-        try:
-            return schema(**payload)
-        except ValidationError as error:
-            raise RequestValidationError(error.errors())
+        return _validate_schema(schema, payload)
 
     return dependency
 

--- a/src/bluecore_api/app/utils/deserializer.py
+++ b/src/bluecore_api/app/utils/deserializer.py
@@ -23,8 +23,15 @@ def deserialize(schema: Type[BaseModel]) -> Callable:
     async def dependency(request: Request) -> BaseModel:
         payload = await request.json()
         content_type = request.headers.get("content-type", "").split(";")[0].strip()
+
+        # Raw JSON-LD (application/ld+json): the whole body is the graph, so wrap
+        # it as the schema's 'data' string.
         if content_type == JSONLD_CONTENT_TYPE:
             return schema(data=json.dumps(payload))
+
+        # Sinopia (application/vnd.sinopia+json, or application/json for backwards
+        # compatibility): already shaped like the schema
+        # ({"data": "<json-ld string>", ...}), so validate it directly
         try:
             return schema(**payload)
         except ValidationError as error:

--- a/src/bluecore_api/app/utils/deserializer.py
+++ b/src/bluecore_api/app/utils/deserializer.py
@@ -1,0 +1,63 @@
+import json
+from typing import Any, Callable, Type
+
+from fastapi import Request
+from fastapi.exceptions import RequestValidationError
+from pydantic import BaseModel, ValidationError
+
+JSONLD_CONTENT_TYPE = "application/ld+json"
+SINOPIA_CONTENT_TYPE = "application/vnd.sinopia+json"
+
+
+def deserialize(schema: Type[BaseModel]) -> Callable:
+    """
+    FastAPI dependency parsing a PUT/POST body by Content-Type into 'schema'.
+
+    'application/ld+json' bodies are raw JSON-LD and are wrapped as the
+    schema's 'data' string; anything else (the Sinopia 'application/vnd.sinopia+json'
+    body, or 'application/json' for backwards compatibility) is validated against
+    the schema directly. Either way the endpoint receives a normal schema instance
+    whose 'data' is a JSON-LD string.
+    """
+
+    async def dependency(request: Request) -> BaseModel:
+        payload = await request.json()
+        content_type = request.headers.get("content-type", "").split(";")[0].strip()
+        if content_type == JSONLD_CONTENT_TYPE:
+            return schema(data=json.dumps(payload))
+        try:
+            return schema(**payload)
+        except ValidationError as error:
+            raise RequestValidationError(error.errors())
+
+    return dependency
+
+
+def request_body_openapi(
+    schema: Type[BaseModel], jsonld_example: dict[str, Any]
+) -> dict:
+    """
+    Document both accepted request bodies for a create/update endpoint.
+
+    These routes read the raw request to support two body media types, so the
+    request body is described here instead of by an auto-parsed body parameter:
+    the Sinopia schema (with an executable example) and a raw JSON-LD example.
+    """
+    # Listed first so Swagger UI defaults to the human-readable, multi-line
+    # JSON-LD example. The Sinopia body's 'data' is a JSON-LD string, which
+    # Swagger can only render as an escaped one-liner.
+    return {
+        "requestBody": {
+            "required": True,
+            "content": {
+                JSONLD_CONTENT_TYPE: {
+                    "schema": {"type": "object"},
+                    "example": jsonld_example,
+                },
+                SINOPIA_CONTENT_TYPE: {
+                    "schema": schema.model_json_schema(),
+                    "example": {"data": json.dumps(jsonld_example)},
+                },
+            },
+        }
+    }

--- a/src/bluecore_api/app/utils/examples.py
+++ b/src/bluecore_api/app/utils/examples.py
@@ -1,0 +1,59 @@
+"""
+Executable JSON-LD request-body examples shown in the OpenAPI docs.
+
+These are used by 'request_body_openapi' to populate the Swagger "Try it out"
+forms for the Work, Instance, and Hub create/update endpoints. Each is a valid,
+self-contained BIBFRAME resource that returns '201' when POSTed as-is.
+"""
+
+_CONTEXT = {
+    "bf": "http://id.loc.gov/ontologies/bibframe/",
+    "bflc": "http://id.loc.gov/ontologies/bflc/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+}
+
+WORK_EXAMPLE = {
+    "@context": _CONTEXT,
+    "@id": "https://api.sinopia.io/resources/example-work-0001",
+    "@type": ["bf:Work", "bf:Text"],
+    "rdfs:label": "Pride and prejudice",
+    "bf:title": {"@type": "bf:Title", "bf:mainTitle": "Pride and prejudice"},
+    "bf:language": {"@id": "http://id.loc.gov/vocabulary/languages/eng"},
+    "bf:content": {"@id": "http://id.loc.gov/vocabulary/contentTypes/txt"},
+    "bf:contribution": {
+        "@type": "bf:Contribution",
+        "bf:agent": {"@type": "bf:Agent", "rdfs:label": "Austen, Jane, 1775-1817"},
+        "bf:role": {"@id": "http://id.loc.gov/vocabulary/relators/aut"},
+    },
+    "bf:classification": {
+        "@type": "bf:ClassificationLcc",
+        "bf:classificationPortion": "PR4034",
+    },
+}
+
+INSTANCE_EXAMPLE = {
+    "@context": _CONTEXT,
+    "@id": "https://api.sinopia.io/resources/example-instance-0001",
+    "@type": ["bf:Instance", "bf:Print"],
+    "rdfs:label": "Pride and prejudice (Penguin Classics, 2003)",
+    "bf:title": {"@type": "bf:Title", "bf:mainTitle": "Pride and prejudice"},
+    "bf:provisionActivity": {
+        "@type": "bf:Publication",
+        "bf:agent": {"@type": "bf:Agent", "rdfs:label": "Penguin Books"},
+        "bf:place": {"@type": "bf:Place", "rdfs:label": "London"},
+        "bf:date": "2003",
+    },
+    "bf:identifiedBy": {"@type": "bf:Isbn", "rdf:value": "9780141439518"},
+    "bf:extent": {"@type": "bf:Extent", "rdfs:label": "435 pages"},
+}
+
+HUB_EXAMPLE = {
+    "@context": _CONTEXT,
+    "@id": "https://api.sinopia.io/resources/example-hub-0001",
+    "@type": "bf:Hub",
+    "rdfs:label": "Austen, Jane, 1775-1817. Pride and prejudice",
+    "bf:title": {"@type": "bf:Title", "bf:mainTitle": "Pride and prejudice"},
+    "bf:language": {"@id": "http://id.loc.gov/vocabulary/languages/eng"},
+    "bflc:aap": "Austen, Jane, 1775-1817. Pride and prejudice",
+}

--- a/tests/api/test_deserializer.py
+++ b/tests/api/test_deserializer.py
@@ -1,0 +1,71 @@
+import json
+
+import pytest
+from fastapi import HTTPException, Request
+from fastapi.exceptions import RequestValidationError
+from pydantic import BaseModel
+
+from bluecore_api.app.utils.deserializer import JSONLD_CONTENT_TYPE, deserialize
+
+
+class RequiredFieldSchema(BaseModel):
+    data: str
+    required: str
+
+
+class DataOnlySchema(BaseModel):
+    data: str
+
+
+def request_with_body(body: bytes, content_type: str) -> Request:
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/",
+            "headers": [(b"content-type", content_type.encode())],
+        },
+        receive,
+    )
+
+
+@pytest.mark.asyncio
+async def test_deserialize_jsonld_wraps_body_as_data():
+    request = request_with_body(
+        json.dumps({"@id": "https://example.com/resource"}).encode(),
+        JSONLD_CONTENT_TYPE,
+    )
+
+    parsed = await deserialize(DataOnlySchema)(request)
+
+    assert json.loads(parsed.data) == {"@id": "https://example.com/resource"}
+
+
+@pytest.mark.asyncio
+async def test_deserialize_invalid_json_raises_unprocessable_entity():
+    request = request_with_body(b"{", JSONLD_CONTENT_TYPE)
+
+    with pytest.raises(HTTPException) as error:
+        await deserialize(DataOnlySchema)(request)
+
+    assert error.value.status_code == 422
+    assert "Invalid JSON body" in error.value.detail
+
+
+@pytest.mark.asyncio
+async def test_deserialize_jsonld_validation_error_becomes_request_validation_error():
+    request = request_with_body(b"{}", JSONLD_CONTENT_TYPE)
+
+    with pytest.raises(RequestValidationError):
+        await deserialize(RequiredFieldSchema)(request)
+
+
+@pytest.mark.asyncio
+async def test_deserialize_shaped_body_validation_error_becomes_request_validation_error():
+    request = request_with_body(b'{"data": "{}"}', "application/vnd.sinopia+json")
+
+    with pytest.raises(RequestValidationError):
+        await deserialize(RequiredFieldSchema)(request)

--- a/tests/api/test_hub.py
+++ b/tests/api/test_hub.py
@@ -179,6 +179,66 @@ def test_update_hub(client, db_session):
     )
 
 
+def test_create_hub_jsonld(client, mocker, derived_from_sparql):
+    """A raw JSON-LD body (application/ld+json) is accepted in addition to the
+    Sinopia-specific body."""
+    original_graph = init_graph()
+    original_graph.parse(
+        data=pathlib.Path("tests/blue-core-hub.jsonld").read_text(), format="json-ld"
+    )
+
+    create_response = client.post(
+        "/hubs/",
+        headers={"X-User": "cataloger", "Content-Type": "application/ld+json"},
+        content=original_graph.serialize(format="json-ld"),
+    )
+
+    assert create_response.status_code == 201
+    data = create_response.json()
+    assert data["data"]["@context"] == CONTEXT_URL
+    assert data["uri"].startswith("https://bcld.info/hubs")
+
+
+def test_update_hub_jsonld(client, db_session):
+    create_response = client.post(
+        "/hubs/",
+        headers={"X-User": "cataloger"},
+        json={"data": pathlib.Path("tests/blue-core-hub.jsonld").read_text()},
+    )
+    assert create_response.status_code == 201
+
+    data = create_response.json()
+    data["data"]["@context"] = CONTEXT
+    hub_uri = rdflib.URIRef(data["uri"])
+    hub_graph = init_graph()
+    hub_graph.parse(data=json.dumps(data["data"]), format="json-ld")
+    hub_graph.add(
+        (
+            hub_uri,
+            rdflib.URIRef("https://schema.org/name"),
+            rdflib.Literal("A JSON-LD Hub Name"),
+        )
+    )
+    hub_uuid = data["uri"].split("/")[-1]
+
+    update_response = client.put(
+        f"/hubs/{hub_uuid}",
+        headers={"X-User": "cataloger", "Content-Type": "application/ld+json"},
+        content=hub_graph.serialize(format="json-ld"),
+    )
+    assert update_response.status_code == 200
+
+    get_response = client.get(f"/hubs/{hub_uuid}.vnd.sinopia.json")
+    data = get_response.json()
+    data["data"]["@context"] = CONTEXT
+    updated_hub_graph = init_graph()
+    updated_hub_graph.parse(data=data["data"], format="json-ld")
+    name = updated_hub_graph.value(
+        subject=hub_uri, predicate=rdflib.URIRef("https://schema.org/name")
+    )
+    assert str(name) == "A JSON-LD Hub Name"
+
+
 def test_get_hub_embedding(client, db_session, vector_client):
     sample_hub_graph = init_graph()
     sample_hub_uuid = "a1b2c3d4-0000-0000-0000-000000000002"

--- a/tests/api/test_instance.py
+++ b/tests/api/test_instance.py
@@ -323,6 +323,66 @@ def test_update_instance(client, db_session):
     )
 
 
+def test_create_instance_jsonld(client, derived_from_sparql):
+    """A raw JSON-LD body (application/ld+json) is accepted in addition to the
+    Sinopia-specific body."""
+    original_graph = init_graph()
+    original_graph.parse(
+        data=pathlib.Path("tests/blue-core-instance.jsonld").read_text(),
+        format="json-ld",
+    )
+
+    response = client.post(
+        "/instances/",
+        headers={"X-User": "cataloger", "Content-Type": "application/ld+json"},
+        content=original_graph.serialize(format="json-ld"),
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["data"]["@context"] == CONTEXT_URL
+    assert data["uri"].startswith("https://bcld.info/instances")
+
+
+def test_update_instance_jsonld(client, db_session):
+    create_response = client.post(
+        "/instances/",
+        headers={"X-User": "cataloger"},
+        json={"data": pathlib.Path("tests/blue-core-instance.jsonld").read_text()},
+    )
+    assert create_response.status_code == 201
+    data = create_response.json()
+    data["data"]["@context"] = CONTEXT
+
+    instance_uri = rdflib.URIRef(data["uri"])
+    instance_uuid = data["uri"].split("/")[-1]
+    instance_graph = init_graph()
+    instance_graph.parse(data=json.dumps(data["data"]), format="json-ld")
+    instance_graph.add(
+        (
+            instance_uri,
+            rdflib.URIRef("https://schema.org/name"),
+            rdflib.Literal("A JSON-LD Instance Name"),
+        )
+    )
+
+    put_response = client.put(
+        f"/instances/{instance_uuid}",
+        headers={"X-User": "cataloger", "Content-Type": "application/ld+json"},
+        content=instance_graph.serialize(format="json-ld"),
+    )
+    assert put_response.status_code == 200
+
+    get_response = client.get(f"/instances/{instance_uuid}.vnd.sinopia.json")
+    payload = get_response.json()
+    payload["data"]["@context"] = CONTEXT
+    new_instance_graph = init_graph()
+    new_instance_graph.parse(data=json.dumps(payload["data"]), format="json-ld")
+    name = new_instance_graph.value(
+        subject=instance_uri, predicate=rdflib.URIRef("https://schema.org/name")
+    )
+    assert str(name) == "A JSON-LD Instance Name"
+
+
 def test_get_instance_embeddings(client, db_session, vector_client):
     sample_instance_graph = init_graph()
     instance_uuid = "3890cc27-6fbf-42b6-8efb-d0ed40e9188e"

--- a/tests/api/test_work.py
+++ b/tests/api/test_work.py
@@ -292,6 +292,46 @@ def test_update_work(client, db_session):
     )
 
 
+def test_create_work_vnd_sinopia_json(client, mocker, derived_from_sparql):
+    """The Sinopia body is accepted under its explicit content type
+    (application/vnd.sinopia+json), not only the legacy application/json."""
+    original_graph = init_graph()
+    original_graph.parse(
+        data=pathlib.Path("tests/blue-core-work.jsonld").read_text(), format="json-ld"
+    )
+
+    create_response = client.post(
+        "/works/",
+        headers={"X-User": "cataloger", "Content-Type": "application/vnd.sinopia+json"},
+        content=json.dumps({"data": original_graph.serialize(format="json-ld")}),
+    )
+
+    assert create_response.status_code == 201
+    data = create_response.json()
+    assert data["data"]["@context"] == CONTEXT_URL
+    assert data["uri"].startswith("https://bcld.info/works")
+
+
+def test_create_work_rdf_xml(client, mocker, derived_from_sparql):
+    """A raw RDF/XML body (application/rdf+xml) is accepted and converted to
+    JSON-LD before being stored."""
+    original_graph = init_graph()
+    original_graph.parse(
+        data=pathlib.Path("tests/blue-core-work.jsonld").read_text(), format="json-ld"
+    )
+
+    create_response = client.post(
+        "/works/",
+        headers={"X-User": "cataloger", "Content-Type": "application/rdf+xml"},
+        content=original_graph.serialize(format="xml"),
+    )
+
+    assert create_response.status_code == 201
+    data = create_response.json()
+    assert data["data"]["@context"] == CONTEXT_URL
+    assert data["uri"].startswith("https://bcld.info/works")
+
+
 def test_create_work_jsonld(client, mocker, derived_from_sparql):
     """A raw JSON-LD body (application/ld+json) is accepted in addition to the
     Sinopia-specific body."""

--- a/tests/api/test_work.py
+++ b/tests/api/test_work.py
@@ -312,26 +312,6 @@ def test_create_work_vnd_sinopia_json(client, mocker, derived_from_sparql):
     assert data["uri"].startswith("https://bcld.info/works")
 
 
-def test_create_work_rdf_xml(client, mocker, derived_from_sparql):
-    """A raw RDF/XML body (application/rdf+xml) is accepted and converted to
-    JSON-LD before being stored."""
-    original_graph = init_graph()
-    original_graph.parse(
-        data=pathlib.Path("tests/blue-core-work.jsonld").read_text(), format="json-ld"
-    )
-
-    create_response = client.post(
-        "/works/",
-        headers={"X-User": "cataloger", "Content-Type": "application/rdf+xml"},
-        content=original_graph.serialize(format="xml"),
-    )
-
-    assert create_response.status_code == 201
-    data = create_response.json()
-    assert data["data"]["@context"] == CONTEXT_URL
-    assert data["uri"].startswith("https://bcld.info/works")
-
-
 def test_create_work_jsonld(client, mocker, derived_from_sparql):
     """A raw JSON-LD body (application/ld+json) is accepted in addition to the
     Sinopia-specific body."""

--- a/tests/api/test_work.py
+++ b/tests/api/test_work.py
@@ -373,6 +373,18 @@ def test_update_work_jsonld(client, db_session):
     assert str(name) == "A JSON-LD Work Name"
 
 
+def test_create_work_malformed_json(client):
+    """A malformed request body returns 422 (not 500) for both the JSON-LD and
+    the Sinopia content types."""
+    for content_type in ("application/ld+json", "application/vnd.sinopia+json"):
+        response = client.post(
+            "/works/",
+            headers={"X-User": "cataloger", "Content-Type": content_type},
+            content="{ this is not valid json ",
+        )
+        assert response.status_code == 422, content_type
+
+
 def test_get_work_embedding(client, db_session, vector_client):
     sample_work_graph = init_graph()
     sample_work_uuid = "55ce1584-9a98-4063-84c9-775c53623142"

--- a/tests/api/test_work.py
+++ b/tests/api/test_work.py
@@ -292,6 +292,67 @@ def test_update_work(client, db_session):
     )
 
 
+def test_create_work_jsonld(client, mocker, derived_from_sparql):
+    """A raw JSON-LD body (application/ld+json) is accepted in addition to the
+    Sinopia-specific body."""
+    original_graph = init_graph()
+    original_graph.parse(
+        data=pathlib.Path("tests/blue-core-work.jsonld").read_text(), format="json-ld"
+    )
+
+    create_response = client.post(
+        "/works/",
+        headers={"X-User": "cataloger", "Content-Type": "application/ld+json"},
+        content=original_graph.serialize(format="json-ld"),
+    )
+
+    assert create_response.status_code == 201
+    data = create_response.json()
+    assert data["data"]["@context"] == CONTEXT_URL
+    assert data["uri"].startswith("https://bcld.info/works")
+
+
+def test_update_work_jsonld(client, db_session):
+    create_response = client.post(
+        "/works/",
+        headers={"X-User": "cataloger"},
+        json={"data": pathlib.Path("tests/blue-core-work.jsonld").read_text()},
+    )
+    assert create_response.status_code == 201
+
+    data = create_response.json()
+    data["data"]["@context"] = CONTEXT
+    work_uri = rdflib.URIRef(data["uri"])
+    work_graph = init_graph()
+    work_graph.parse(data=json.dumps(data["data"]), format="json-ld")
+    work_graph.add(
+        (
+            work_uri,
+            rdflib.URIRef("https://schema.org/name"),
+            rdflib.Literal("A JSON-LD Work Name"),
+        )
+    )
+    work_uuid = data["uri"].split("/")[-1]
+
+    update_response = client.put(
+        f"/works/{work_uuid}",
+        headers={"X-User": "cataloger", "Content-Type": "application/ld+json"},
+        content=work_graph.serialize(format="json-ld"),
+    )
+    assert update_response.status_code == 200
+    assert update_response.json()["data"]["@context"] == CONTEXT_URL
+
+    get_response = client.get(f"/works/{work_uuid}.vnd.sinopia.json")
+    data = get_response.json()
+    data["data"]["@context"] = CONTEXT
+    updated_work_graph = init_graph()
+    updated_work_graph.parse(data=data["data"], format="json-ld")
+    name = updated_work_graph.value(
+        subject=work_uri, predicate=rdflib.URIRef("https://schema.org/name")
+    )
+    assert str(name) == "A JSON-LD Work Name"
+
+
 def test_get_work_embedding(client, db_session, vector_client):
     sample_work_graph = init_graph()
     sample_work_uuid = "55ce1584-9a98-4063-84c9-775c53623142"


### PR DESCRIPTION
### closes #236


## Why was this change made?                                                                                                                                                                                                                                                                                                
The Work, Instance, and Hub `POST`/`PUT` endpoints only accepted the Sinopia-specific wrapped-JSON body. 
This adds content negotiation on writes so they also accept raw `application/ld+json`, with the Sinopia body identified 
by `application/vnd.sinopia+json` (and `application/json` still accepted for backwards compatibility).

## How was this change tested?                                                                                                                                                                                                                                                                                            
New API tests exercise both content types end-to-end through the FastAPI test client and a real DB:
- Added additional test cases.

## Which documentation and/or configurations were updated?
- OpenAPI/Swagger docs: each Work/Instance/Hub create & update endpoint now documents both request media types via `openapi_extra`, each with an executable "Try it out" example.                                                                                                                                         
- Added `src/bluecore_api/app/utils/examples.py` holding the JSON-LD request-body examples (`WORK_EXAMPLE`, 
`INSTANCE_EXAMPLE`, `HUB_EXAMPLE`).                                                                                                                                                                           


## Screenshots
<img width="645" height="617" alt="image" src="https://github.com/user-attachments/assets/97a7ddfb-1b8d-4151-838e-322e8b181182" />
<img width="645" height="617" alt="image" src="https://github.com/user-attachments/assets/089daea1-2a35-461a-b4b6-f2d1a8311168" />
