### PR TITLE
262 isbn lccn missing from view fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluecore-api"
-version = "0.23.1"
+version = "0.23.2"
 description = "Blue Core API for managing BIBFRAME RDF data and workflows"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/bluecore_api/app/utils/serialize/html.py
+++ b/src/bluecore_api/app/utils/serialize/html.py
@@ -23,12 +23,14 @@ RDF_VALUE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#value"
 # compacted prefixed form (e.g. identifiers from the API context use "rdf:value").
 RDF_VALUE_KEYS = (RDF_VALUE, "rdf:value")
 
+
 def _rdf_value(node: dict[str, Any]) -> Any:
     """Return the rdf:value of a node, whichever key form it uses."""
     for key in RDF_VALUE_KEYS:
         if key in node:
             return node[key]
     return None
+
 
 # (json-ld key, human label) in display order. Mirrors the mockups.
 INSTANCE_FIELDS: list[tuple[str, str]] = [

--- a/src/bluecore_api/app/utils/serialize/html.py
+++ b/src/bluecore_api/app/utils/serialize/html.py
@@ -19,6 +19,16 @@ from bluecore_models.utils.graph import load_jsonld
 from bluecore_api.app.templating import BLUECORE_URL, templates
 
 RDF_VALUE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#value"
+# The stored JSON-LD may carry rdf:value either fully expanded or in its
+# compacted prefixed form (e.g. identifiers from the API context use "rdf:value").
+RDF_VALUE_KEYS = (RDF_VALUE, "rdf:value")
+
+def _rdf_value(node: dict[str, Any]) -> Any:
+    """Return the rdf:value of a node, whichever key form it uses."""
+    for key in RDF_VALUE_KEYS:
+        if key in node:
+            return node[key]
+    return None
 
 # (json-ld key, human label) in display order. Mirrors the mockups.
 INSTANCE_FIELDS: list[tuple[str, str]] = [
@@ -86,8 +96,8 @@ def _label_text(node: Any) -> str:
     ):
         if key in node:
             return _scalar(node[key])
-    if RDF_VALUE in node:
-        return _scalar(node[RDF_VALUE]).strip()
+    if any(key in node for key in RDF_VALUE_KEYS):
+        return _scalar(_rdf_value(node)).strip()
     if "code" in node:
         return _scalar(node["code"])
     if "@value" in node:
@@ -155,7 +165,7 @@ def _node_values(node: Any, label_map: dict[str, str]) -> list[dict[str, Any]]:
     return values
 
 
-def _identifier_values(node: Any) -> list[dict[str, Any]]:
+def _identifier_values(node: Any, label_map: dict[str, str]) -> list[dict[str, Any]]:
     values: list[dict[str, Any]] = []
     for item in _as_list(node):
         if not isinstance(item, dict):
@@ -163,8 +173,20 @@ def _identifier_values(node: Any) -> list[dict[str, Any]]:
         bf_type = item.get("@type", "")
         if isinstance(bf_type, list):
             bf_type = bf_type[0] if bf_type else ""
-        ident = _scalar(item.get(RDF_VALUE, "")).strip()
-        values.append(_value(f"{bf_type}: {ident}".strip()))
+        ident = _scalar(_rdf_value(item) or "").strip()
+        text = f"{bf_type}: {ident}".strip()
+        # Qualifier (e.g. "epub") and status (e.g. cancelled/invalid) tell apart
+        # otherwise identical-looking numbers, so show them alongside the value.
+        qualifier = _scalar(item.get("qualifier", "")).strip()
+        status = item.get("status")
+        status_href = status.get("@id") if isinstance(status, dict) else None
+        status_text = _resolve_label(
+            status_href, _label_text(status) if status else "", label_map
+        )
+        extras = [e for e in (qualifier, status_text) if e]
+        if extras:
+            text = f"{text} ({', '.join(extras)})"
+        values.append(_value(text))
     return values
 
 
@@ -318,7 +340,7 @@ def _field(
     if key not in data:
         return None
     if key == "identifiedBy":
-        values = _identifier_values(data[key])
+        values = _identifier_values(data[key], label_map)
     elif key == "contribution":
         values = _contribution_values(data[key], label_map)
     elif key == "classification":

--- a/tests/utils/test_serialize_html.py
+++ b/tests/utils/test_serialize_html.py
@@ -1,0 +1,90 @@
+"""Unit tests for the identifier rendering in the HTML serializer.
+
+Exercises _identifier_values directly so the ISBN/LCCN behavior is covered
+regardless of which rdf:value key form the stored JSON-LD uses.
+"""
+
+from bluecore_api.app.utils.serialize.html import _identifier_values, _rdf_value
+
+RDF_VALUE_URI = "http://www.w3.org/1999/02/22-rdf-syntax-ns#value"
+CANCINV = "http://id.loc.gov/vocabulary/mstatus/cancinv"
+
+
+def _texts(values):
+    return [v["text"] for v in values]
+
+
+def test_identifier_values_prefixed_rdf_value_key():
+    """Identifiers using the compacted "rdf:value" key are retrieved."""
+    node = [
+        {"@type": "Lccn", "rdf:value": "  2021062674"},
+        {"@type": "Isbn", "rdf:value": "9781000607260"},
+    ]
+    assert _texts(_identifier_values(node, {})) == [
+        "Lccn: 2021062674",
+        "Isbn: 9781000607260",
+    ]
+
+
+def test_identifier_values_expanded_rdf_value_key():
+    """Identifiers using the fully-expanded rdf:value URI are retrieved too."""
+    node = [
+        {"@type": "Lccn", RDF_VALUE_URI: "2021062674"},
+        {"@type": "Isbn", RDF_VALUE_URI: "9781000607260"},
+    ]
+    assert _texts(_identifier_values(node, {})) == [
+        "Lccn: 2021062674",
+        "Isbn: 9781000607260",
+    ]
+
+
+def test_identifier_values_includes_qualifier():
+    node = [{"@type": "Isbn", "qualifier": "epub", "rdf:value": "9781000607260"}]
+    assert _texts(_identifier_values(node, {})) == ["Isbn: 9781000607260 (epub)"]
+
+
+def test_identifier_values_status_falls_back_to_code():
+    """Without a label map the status shows its vocabulary code tail."""
+    node = [
+        {
+            "@type": "Isbn",
+            "qualifier": "paperback",
+            "status": {"@id": CANCINV},
+            "rdf:value": "9781032075129",
+        }
+    ]
+    assert _texts(_identifier_values(node, {})) == [
+        "Isbn: 9781032075129 (paperback, cancinv)"
+    ]
+
+
+def test_identifier_values_status_resolves_label():
+    """A status URI present in the label map renders its human label."""
+    node = [
+        {
+            "@type": "Isbn",
+            "qualifier": "paperback",
+            "status": {"@id": CANCINV},
+            "rdf:value": "9781032075129",
+        }
+    ]
+    label_map = {CANCINV: "cancelled or invalid"}
+    assert _texts(_identifier_values(node, label_map)) == [
+        "Isbn: 9781032075129 (paperback, cancelled or invalid)"
+    ]
+
+
+def test_identifier_values_single_node_not_wrapped_in_list():
+    node = {"@type": "Lccn", "rdf:value": "2021062674"}
+    assert _texts(_identifier_values(node, {})) == ["Lccn: 2021062674"]
+
+
+def test_identifier_values_skips_non_dict_items():
+    node = ["not-a-dict", {"@type": "Isbn", "rdf:value": "9781000607260"}]
+    assert _texts(_identifier_values(node, {})) == ["Isbn: 9781000607260"]
+
+
+def test_rdf_value_prefers_available_key_form():
+    assert _rdf_value({"rdf:value": "a"}) == "a"
+    assert _rdf_value({RDF_VALUE_URI: "b"}) == "b"
+    assert _rdf_value({"@type": "Isbn"}) is None

--- a/uv.lock
+++ b/uv.lock
@@ -88,7 +88,7 @@ wheels = [
 
 [[package]]
 name = "bluecore-api"
-version = "0.23.1"
+version = "0.23.2"
 source = { editable = "." }
 dependencies = [
     { name = "bluecore-models" },


### PR DESCRIPTION
### Closes #262 

## Why was this change made?
ISBNs and LCCNs were missing in the html view. Updated to correctly show values in view


## How was this change tested?
Locally with pytest and viewing html view outputs


## Which documentation and/or configurations were updated?
n/a

## Screenshots

### Before
<img width="1082" height="958" alt="image" src="https://github.com/user-attachments/assets/38359b82-5af6-474c-86f9-2a2b8d7fab0c" />


### After
<img width="1082" height="958" alt="image" src="https://github.com/user-attachments/assets/90561d9d-fdff-47d4-8b31-d0cef2a7fde2" />


