### PR TITLE
Route archive uploads to the archived_file_loader DAG

### DIFF
--- a/src/bluecore_api/app/routes/batches.py
+++ b/src/bluecore_api/app/routes/batches.py
@@ -14,6 +14,18 @@ from bluecore_api.schemas.schemas import BatchCreateSchema, BatchSchema
 
 endpoints = APIRouter()
 
+# File extensions that indicate an archive of RDF files to be bulk loaded via
+# the archived_file_loader DAG rather than the single-file resource_loader DAG.
+ARCHIVE_SUFFIXES = (".zip", ".tar.gz", ".tgz", ".gz")
+
+
+def _dag_for_filename(filename: str) -> str:
+    """Pick the Airflow DAG based on whether the upload is an archive."""
+    lower = filename.lower()
+    if any(lower.endswith(suffix) for suffix in ARCHIVE_SUFFIXES):
+        return "archived_file_loader"
+    return "resource_loader"
+
 
 def _xml_to_jsonld_and_save(
     upload_root: Path, xml_data: bytes | str, name: str | None = None
@@ -91,7 +103,9 @@ async def create_batch_file(
 
             file_location = f"/opt/airflow/uploads/{batch_file}"
             workflow_id = await workflow.create_batch_from_uri(
-                file_location, user_uid=user_uid
+                file_location,
+                user_uid=user_uid,
+                dag_id=_dag_for_filename(file.filename),
             )
             return {"uri": file_location, "workflow_id": workflow_id}
 

--- a/src/bluecore_api/cli.py
+++ b/src/bluecore_api/cli.py
@@ -34,7 +34,9 @@ def load_file(
     ],
 ):
     """
-    Upload a Bibframe JSON-LD file as a batch import.
+    Upload a Bibframe file as a batch import. Accepts a single RDF file
+    (JSON-LD or RDF/XML) or a zip/tar.gz archive of RDF files, which is bulk
+    loaded via the archived_file_loader workflow.
     """
     try:
         token = _get_token()

--- a/src/bluecore_api/workflow.py
+++ b/src/bluecore_api/workflow.py
@@ -11,17 +11,23 @@ AIRFLOW_PASSWORD = os.environ.get("AIRFLOW_WWW_USER_PASSWORD")
 AIRFLOW_INTERNAL_URL = os.environ.get("AIRFLOW_INTERNAL_URL").rstrip("/")
 
 
-async def create_batch_from_uri(uri: str, user_uid: str | None = None) -> str:
+async def create_batch_from_uri(
+    uri: str,
+    user_uid: str | None = None,
+    dag_id: str = "resource_loader",
+) -> str:
     """
     uri: Start an Airflow DAG run to process data at a given URI. Returns the ID
          for the created DAG Run. A URI can have https, http, s3 or file protocol.
     user_uid: Keycloak subject/UID of the caller (optional). When provided, it will
               be available to the DAG as dag_run.conf["user_uid"].
+    dag_id: The Airflow DAG to trigger. Defaults to "resource_loader" for a single
+            RDF file; use "archived_file_loader" for a zip/tar.gz of RDF files.
     """
 
     token = await get_token()
 
-    url = f"{AIRFLOW_INTERNAL_URL}/api/v2/dags/resource_loader/dagRuns"
+    url = f"{AIRFLOW_INTERNAL_URL}/api/v2/dags/{dag_id}/dagRuns"
     now = datetime.datetime.now(tz=datetime.UTC).isoformat()
 
     # Put the UID into the DAG run's conf so tasks can read it

--- a/tests/api/test_batches.py
+++ b/tests/api/test_batches.py
@@ -187,6 +187,42 @@ async def test_upload_raw_xml_body(
 
 
 # ------------------------------
+# /batches/upload/ (archive -> archived_file_loader DAG)
+# ------------------------------
+@pytest.mark.asyncio
+@pytest.mark.parametrize("filename", ["records.zip", "records.tar.gz", "records.tgz"])
+async def test_upload_archive_routes_to_archive_loader(
+    client, httpx_mock: HTTPXMock, monkeypatch, tmp_path, filename
+):
+    monkeypatch.chdir(tmp_path)
+    # token
+    httpx_mock.add_response(
+        method="POST",
+        url=re.compile(r"^http://airflow:8080/auth/token$"),
+        json={"access_token": "xxx"},
+    )
+    # archive uploads should trigger the archived_file_loader DAG, not resource_loader
+    httpx_mock.add_response(
+        method="POST",
+        url=re.compile(r".*/api/v2/dags/archived_file_loader/dagRuns$"),
+        json={"dag_run_id": "archive-999"},
+    )
+
+    files = {"file": (filename, b"not-a-real-archive", "application/octet-stream")}
+    resp = client.post("/batches/upload/", headers={"X-User": "cataloger"}, files=files)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["workflow_id"] == "archive-999"
+    assert data["uri"].endswith(f"/{filename}")
+
+    # the file is passed through as-is for the DAG to unpack
+    saved_rel = data["uri"].split("uploads/")[-1]
+    saved_path = Path("./uploads") / saved_rel
+    assert saved_path.is_file()
+    assert saved_path.read_bytes() == b"not-a-real-archive"
+
+
+# ------------------------------
 # Error cases
 # ------------------------------
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Lets the `bluecore load-file` CLI command (and the `/batches/upload/` API endpoint) accept a **zip or tar.gz archive of RDF files** for bulk loading, not just a single JSON-LD/RDF file.

## Why

The `archived_file_loader` DAG in `bluecore-workflows` already knows how to unpack an archive, batch the RDF files inside, and bulk load them in parallel — but nothing ever triggered it. Every upload was hardcoded to the single-file `resource_loader` DAG, which parses one JSON-LD file and would fail on an archive.

## How

- `workflow.create_batch_from_uri` gains a `dag_id` parameter (default `resource_loader`).
- `batches.py` adds `_dag_for_filename()`: `.zip` / `.tar.gz` / `.tgz` / `.gz` route to `archived_file_loader`, everything else keeps using `resource_loader`. The file is still saved as-is for the DAG to unpack.
- `cli.py`: updated `load-file` help text (no behavior change — it already streams any file as multipart).
- Added a parametrized test asserting archive uploads trigger `archived_file_loader` and pass the bytes through untouched.

Manually verified end-to-end against a running stack: a `.tar.gz` upload triggers `archived_file_loader` and loads the records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)