### PR TITLE
Support overlaying an existing catalog record by local_id in /export/

### DIFF
--- a/src/bluecore_api/app/routes/export.py
+++ b/src/bluecore_api/app/routes/export.py
@@ -1,5 +1,7 @@
+from typing import Annotated
+
 from bluecore_models.models.version import CURRENT_USER_ID
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Body, Depends, HTTPException
 
 from bluecore_api import workflow
 from bluecore_api.constants import READ_ONLY_ROLES, KeycloakRole
@@ -10,6 +12,27 @@ from bluecore_api.schemas.schemas import ExportResponseSchema, ExportSchema
 
 endpoints = APIRouter()
 
+EXPORT_EXAMPLES = {
+    "by_instance_uri": {
+        "summary": "Export by Bluecore instance URI",
+        "description": "instance_uri is required; local_id is optional and may "
+        "be omitted entirely.",
+        "value": {
+            "instance_uri": "https://bcld.info/instances/8836b3c5-9bc6-421b-9591-df25499cd93c"
+        },
+    },
+    "overlay_by_local_id": {
+        "summary": "Overlay an existing catalog record by local identifier",
+        "description": "instance_uri is still required to identify the source "
+        "data; local_id additionally targets an existing catalog record "
+        "(e.g. HRID) to overlay.",
+        "value": {
+            "instance_uri": "https://bcld.info/instances/8836b3c5-9bc6-421b-9591-df25499cd93c",
+            "local_id": "a123456",
+        },
+    },
+}
+
 
 @endpoints.post(
     "/export/",
@@ -17,7 +40,9 @@ endpoints = APIRouter()
     response_model=ExportResponseSchema,
     operation_id="export",
 )
-async def export_to_lsp(export: ExportSchema):
+async def export_to_lsp(
+    export: Annotated[ExportSchema, Body(openapi_examples=EXPORT_EXAMPLES)],
+):
     """
     Triggers Workflows DAG for exporting Instance and Work to an insitution's
     Library Services Platform (LSP) like FOLIO or Alma.
@@ -26,8 +51,14 @@ async def export_to_lsp(export: ExportSchema):
 
     try:
         workflow_id = await workflow.export_instance(
-            instance_uri=export.instance_uri, user_uid=user_uid
+            instance_uri=export.instance_uri,
+            local_id=export.local_id,
+            user_uid=user_uid,
         )
     except workflow.WorkflowError as e:
         raise HTTPException(status_code=503, detail=str(e))
-    return {"instance_uri": export.instance_uri, "workflow_id": workflow_id}
+    return {
+        "instance_uri": export.instance_uri,
+        "local_id": export.local_id,
+        "workflow_id": workflow_id,
+    }

--- a/src/bluecore_api/schemas/schemas.py
+++ b/src/bluecore_api/schemas/schemas.py
@@ -133,8 +133,10 @@ class SearchProfileResultSchema(BaseModel):
 
 class ExportSchema(BaseModel):
     instance_uri: str
+    local_id: str | None = None
 
 
 class ExportResponseSchema(BaseModel):
     instance_uri: str
+    local_id: str | None = None
     workflow_id: str

--- a/src/bluecore_api/workflow.py
+++ b/src/bluecore_api/workflow.py
@@ -46,12 +46,17 @@ async def create_batch_from_uri(uri: str, user_uid: str | None = None) -> str:
         return job_id
 
 
-async def export_instance(instance_uri: str, user_uid: str) -> str:
+async def export_instance(
+    user_uid: str, instance_uri: str, local_id: str | None = None
+) -> str:
     """
     Triggers the monitor_export_api DAG run that exports the Instance and Work to
     institution's LSP based on the user's group.
 
-    instance_uri: Blue Core Instance URI
+    instance_uri: Blue Core Instance URI.
+    local_id: Optional institution-local identifier (e.g. an HRID, or another
+              institution's equivalent) of an existing catalog record to overlay,
+              instead of resolving the target record from instance_uri alone.
     user_uid: Keycloak subject/UID
     """
     token = await get_token()
@@ -59,7 +64,12 @@ async def export_instance(instance_uri: str, user_uid: str) -> str:
     url = f"{AIRFLOW_INTERNAL_URL}/api/v2/dags/monitor_institutions_exports/dagRuns"
     now = datetime.datetime.now(tz=datetime.UTC).isoformat()
 
-    conf = {"resource": instance_uri, "user": user_uid}
+    # NOTE: the "local_id" conf key is provisional and needs to be confirmed against
+    # (or coordinated with) the monitor_institutions_exports DAG definition in
+    # bluecore-workflows, which today only reads "resource" from conf. "resource"
+    # is always present; "local_id" is present only when an overlay target
+    # identifier was submitted, otherwise it's sent as null.
+    conf = {"resource": instance_uri, "local_id": local_id, "user": user_uid}
 
     async with httpx.AsyncClient() as client:
         try:
@@ -72,7 +82,7 @@ async def export_instance(instance_uri: str, user_uid: str) -> str:
             job_id = resp.json().get("dag_run_id")
         except httpx.HTTPError as e:
             logger.error(e)
-            match resp.response_code:
+            match resp.status_code:
                 case 401:
                     raise WorkflowError("Invalid credentials for Bluecore Workflow API")
 

--- a/tests/api/test_export.py
+++ b/tests/api/test_export.py
@@ -1,3 +1,4 @@
+import json
 import re
 
 import pytest
@@ -32,3 +33,72 @@ async def test_export(client, httpx_mock: HTTPXMock):
     data = response.json()
     assert data["workflow_id"].startswith("12345")
     assert data["instance_uri"].endswith("df25499cd93c")
+
+    # ensure the conf sent to airflow always includes both keys, with the unused
+    # identifier sent as null
+    dag_run_request = httpx_mock.get_requests()[1]
+    conf = json.loads(dag_run_request.content)["conf"]
+    assert conf["resource"].endswith("df25499cd93c")
+    assert conf["local_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_export_with_local_id(client, httpx_mock: HTTPXMock):
+    # Mock calls the keycloak token for the airflow_workflows client
+    httpx_mock.add_response(
+        method="POST",
+        url=(re.compile(r"^http://airflow:8080/auth/token$")),
+        json={"access_token": "xxx"},
+    )
+
+    # mock the call to airflow api
+    httpx_mock.add_response(
+        method="POST",
+        url=re.compile(r".*/api/v2/dags/monitor_institutions_exports/dagRuns$"),
+        json={"dag_run_id": "12345"},
+    )
+
+    response = client.post(
+        "/export/",
+        headers={"X-User": "cataloger"},
+        json={
+            "instance_uri": "https://bcld.info/instances/8836b3c5-9bc6-421b-9591-df25499cd93c",
+            "local_id": "a123456",
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["workflow_id"].startswith("12345")
+    assert data["local_id"] == "a123456"
+    assert data["instance_uri"].endswith("df25499cd93c")
+
+    # ensure the conf sent to airflow always includes both keys
+    dag_run_request = httpx_mock.get_requests()[1]
+    conf = json.loads(dag_run_request.content)["conf"]
+    assert conf["local_id"] == "a123456"
+    assert conf["resource"].endswith("df25499cd93c")
+
+
+@pytest.mark.asyncio
+async def test_export_rejects_local_id_without_instance_uri(
+    client, httpx_mock: HTTPXMock
+):
+    response = client.post(
+        "/export/",
+        headers={"X-User": "cataloger"},
+        json={"local_id": "a123456"},
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_export_rejects_missing_instance_uri(client, httpx_mock: HTTPXMock):
+    response = client.post(
+        "/export/",
+        headers={"X-User": "cataloger"},
+        json={},
+    )
+
+    assert response.status_code == 422


### PR DESCRIPTION
## Why was this change made?
Fixes #267 


## How was this change tested?
modified:   tests/api/test_export.py


## Which documentation and/or configurations were updated?
Modified the API docs to reflect the new export body.

