### PR TITLE
Fix language tag bug

### DIFF
--- a/src/bluecore_api/xsl/utils.xsl
+++ b/src/bluecore_api/xsl/utils.xsl
@@ -93,7 +93,8 @@
         </xsl:variable>
         <xsl:choose>
           <xsl:when test="$vLang = 'en' and $vScript != '' and $vScript != 'latn'"><xsl:value-of select="concat('und-',$vScript)"/></xsl:when>
-          <xsl:when test="$bcp47inferrence and 
+          <xsl:when test="$bcp47inferrence and
+                          $vScript != '' and
                           $code-to-script-map/code-to-script-map/entry[@key=$vLang] and
                           $code-to-script-map/code-to-script-map/entry[@key=$vLang]/value != $vScript">
             <xsl:value-of select="concat($vLang,'-',$vScript)"/>


### PR DESCRIPTION
## Why was this change made?

Note: I've confirmed this fix by converting a marc record known to have this language code before and after the change. I apparently can't upload .mrc files but can provide it if the reviewer would like.

There is an issue in the XSLT conversion with some language tags (in this case `ara`):

```
The issue is in the 880 fields. The $6 subfield has //r at the end — that r is the script code for "Arabic script". The marc2bibframe2 XSLT is using that script code to derive a
  xml:lang value. It maps ara → BCP 47 ar, but when it tries to append the script subtag from the //r code, it's not resolving r to a valid BCP 47 script subtag (like Arab), leaving
  just ar- with a trailing hyphen.

  This is a known behavior in the LC marc2bibframe2 XSLT — it expects the MARC script code in $6 to map to a BCP 47 script subtag, but //r (an older/shorthand MARC convention for
  right-to-left) doesn't have a clean mapping, so the XSLT produces ar- (base language tag + dangling hyphen where the script subtag should go). The r is a directionality indicator,
  not a script code, but the XSLT treats it as one.
```

This fixes that bug by using a guard clause on the `$vScript` value not being empty.

## How was this change tested?



## Which documentation and/or configurations were updated?




