### PR TITLE
Add export keycloak role for to the export endpoint

### DIFF
--- a/src/bluecore_api/app/routes/export.py
+++ b/src/bluecore_api/app/routes/export.py
@@ -36,7 +36,7 @@ EXPORT_EXAMPLES = {
 
 @endpoints.post(
     "/export/",
-    dependencies=[Depends(BCP(KeycloakRole.CREATE, READ_ONLY_ROLES))],
+    dependencies=[Depends(BCP(KeycloakRole.EXPORT, READ_ONLY_ROLES))],
     response_model=ExportResponseSchema,
     operation_id="export",
 )

--- a/src/bluecore_api/constants.py
+++ b/src/bluecore_api/constants.py
@@ -24,6 +24,7 @@ class KeycloakRole(StrEnum):
 
     CATALOGER_READ_ONLY = "cataloger-read-only"
     CREATE = auto()
+    EXPORT = auto()
     UPDATE = auto()
 
 

--- a/src/bluecore_api/middleware/keycloak_auth.py
+++ b/src/bluecore_api/middleware/keycloak_auth.py
@@ -10,7 +10,11 @@ from bluecore_api.middleware.helpers.keycloak_utils import (
 
 def enable_developer_mode(app):
     """Bypass Keycloak auth in dev mode by setting DEVELOPER_MODE=true"""
-    developer_permissions = ["create", "update"]  # update to add more permissions
+    developer_permissions = [
+        "create",
+        "export",
+        "update",
+    ]  # update to add more permissions
 
     async def mocked_get_auth(request: Request):
         return developer_permissions

--- a/tests/api/test_export.py
+++ b/tests/api/test_export.py
@@ -102,3 +102,43 @@ async def test_export_rejects_missing_instance_uri(client, httpx_mock: HTTPXMock
     )
 
     assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_export_allowed_with_export_role(client, httpx_mock: HTTPXMock):
+    """User with only the 'export' role (no create/update) can export."""
+    httpx_mock.add_response(
+        method="POST",
+        url=(re.compile(r"^http://airflow:8080/auth/token$")),
+        json={"access_token": "xxx"},
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url=re.compile(r".*/api/v2/dags/monitor_institutions_exports/dagRuns$"),
+        json={"dag_run_id": "99999"},
+    )
+
+    response = client.post(
+        "/export/",
+        headers={"X-User": "public", "X-Roles": "export"},
+        json={
+            "instance_uri": "https://bcld.info/instances/8836b3c5-9bc6-421b-9591-df25499cd93c"
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["workflow_id"].startswith("99999")
+
+
+@pytest.mark.asyncio
+async def test_export_rejected_without_export_role(client, httpx_mock: HTTPXMock):
+    """User with create role but no export role cannot export."""
+    response = client.post(
+        "/export/",
+        headers={"X-User": "public", "X-Roles": "create"},
+        json={
+            "instance_uri": "https://bcld.info/instances/8836b3c5-9bc6-421b-9591-df25499cd93c"
+        },
+    )
+
+    assert response.status_code == 403

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,7 +56,7 @@ async def mocked_get_auth(request: Request):
 
     match user:
         case "cataloger":
-            roles = ["create", "update"]
+            roles = ["create", "export", "update"]
         case "cataloger-conflicting":
             roles = ["cataloger-read-only", "create"]
 


### PR DESCRIPTION
## Why was this change made?

Fixes #220 

Changes:

1. src/bluecore_api/constants.py — Added EXPORT = auto() to KeycloakRole enum
2. src/bluecore_api/app/routes/export.py — Changed permission from KeycloakRole.CREATE to KeycloakRole.EXPORT
3. src/bluecore_api/middleware/keycloak_auth.py — Added "export" to developer mode permissions
4. tests/conftest.py — Added "export" to the "cataloger" mock user roles
5. tests/api/test_export.py — Added two tests: one verifying export-only role works, one verifying create-only role is rejected

## How was this change tested?



## Which documentation and/or configurations were updated?




